### PR TITLE
[feat] 강의 조회 및 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/lxp/config/AppConfig.java
+++ b/src/main/java/com/lxp/config/AppConfig.java
@@ -5,9 +5,18 @@ import com.lxp.view.MainView;
 public class AppConfig {
 
 	private final RepositoryConfig repositoryConfig = new RepositoryConfig();
+	private final MockDataInitializer mockDataInitializer = new MockDataInitializer(
+		repositoryConfig.instructorRepository(),
+		repositoryConfig.courseRepository(),
+		repositoryConfig.contentRepository()
+	);
 	private final ServiceConfig serviceConfig = new ServiceConfig(repositoryConfig);
 	private final ControllerConfig controllerConfig = new ControllerConfig(serviceConfig);
 	private final ViewConfig viewConfig = new ViewConfig(controllerConfig);
+
+	public AppConfig() {
+		mockDataInitializer.initialize();
+	}
 
 	public MainView mainView() {
 		return viewConfig.mainView();

--- a/src/main/java/com/lxp/config/MockDataInitializer.java
+++ b/src/main/java/com/lxp/config/MockDataInitializer.java
@@ -1,0 +1,91 @@
+package com.lxp.config;
+
+import com.lxp.domain.Content;
+import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
+import com.lxp.domain.enums.ContentType;
+import com.lxp.domain.enums.Level;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.CourseRepository;
+import com.lxp.repository.InstructorRepository;
+
+public class MockDataInitializer {
+
+	private final InstructorRepository instructorRepository;
+	private final CourseRepository courseRepository;
+	private final ContentRepository contentRepository;
+
+	public MockDataInitializer(
+		InstructorRepository instructorRepository,
+		CourseRepository courseRepository,
+		ContentRepository contentRepository
+	) {
+		this.instructorRepository = instructorRepository;
+		this.courseRepository = courseRepository;
+		this.contentRepository = contentRepository;
+	}
+
+	public void initialize() {
+		if (!instructorRepository.findAll().isEmpty() || !courseRepository.findAll().isEmpty()) {
+			return;
+		}
+
+		Instructor javaInstructor = instructorRepository.save(
+			Instructor.create("김남준", "10년 경력의 자바 전문 강사입니다.")
+		);
+		Instructor springInstructor = instructorRepository.save(
+			Instructor.create("홍길동", "실무 중심 스프링 백엔드 강사입니다.")
+		);
+
+		Course javaCourse = courseRepository.save(Course.create(
+			javaInstructor.getId(),
+			"자바의 정석",
+			"자바 기초부터 심화까지 다루는 강의입니다.",
+			100000,
+			Level.LOW
+		));
+		Course springCourse = courseRepository.save(Course.create(
+			springInstructor.getId(),
+			"스프링 실전",
+			"스프링 부트 기반 백엔드 실전 강의입니다.",
+			149000,
+			Level.MIDDLE
+		));
+
+		contentRepository.save(Content.create(
+			javaCourse.getId(),
+			"원시타입",
+			"원시타입과 참조타입의 차이를 이해합니다.",
+			ContentType.TEXT,
+			1
+		));
+		contentRepository.save(Content.create(
+			javaCourse.getId(),
+			"for 문",
+			"반복문의 기본 구조와 사용법을 익힙니다.",
+			ContentType.TEXT,
+			2
+		));
+		contentRepository.save(Content.create(
+			javaCourse.getId(),
+			"Stream",
+			"스트림 API로 컬렉션을 처리하는 방법을 학습합니다.",
+			ContentType.TEXT,
+			3
+		));
+		contentRepository.save(Content.create(
+			springCourse.getId(),
+			"DI와 IoC",
+			"스프링 컨테이너와 의존성 주입 개념을 이해합니다.",
+			ContentType.TEXT,
+			1
+		));
+		contentRepository.save(Content.create(
+			springCourse.getId(),
+			"JPA 기초",
+			"엔티티 매핑과 영속성 컨텍스트를 학습합니다.",
+			ContentType.TEXT,
+			2
+		));
+	}
+}

--- a/src/main/java/com/lxp/config/ViewConfig.java
+++ b/src/main/java/com/lxp/config/ViewConfig.java
@@ -2,7 +2,9 @@ package com.lxp.config;
 
 import java.util.Scanner;
 
+import com.lxp.view.CourseDetailView;
 import com.lxp.view.CourseListView;
+import com.lxp.view.CourseSelectView;
 import com.lxp.view.CourseView;
 import com.lxp.view.InputView;
 import com.lxp.view.InstructorDetailView;
@@ -24,6 +26,8 @@ public class ViewConfig {
 
 	private final InstructorDetailView instructorDetailView;
 	private final InstructorSelectView instructorSelectView;
+	private final CourseDetailView courseDetailView;
+	private final CourseSelectView courseSelectView;
 	private final CourseListView courseListView;
 	private final InstructorListView instructorListView;
 	private final CourseView courseView;
@@ -44,10 +48,22 @@ public class ViewConfig {
 			this.controllerConfig.instructorController(),
 			instructorDetailView
 		);
-		this.courseListView = new CourseListView(
+		this.courseDetailView = new CourseDetailView(
 			menuRenderer,
 			outputView,
 			this.controllerConfig.courseController()
+		);
+		this.courseSelectView = new CourseSelectView(
+			menuRenderer,
+			outputView,
+			this.controllerConfig.courseController(),
+			courseDetailView
+		);
+		this.courseListView = new CourseListView(
+			menuRenderer,
+			outputView,
+			this.controllerConfig.courseController(),
+			courseSelectView
 		);
 		this.instructorListView = new InstructorListView(
 			menuRenderer,

--- a/src/main/java/com/lxp/controller/CourseController.java
+++ b/src/main/java/com/lxp/controller/CourseController.java
@@ -1,8 +1,15 @@
 package com.lxp.controller;
 
+import java.util.List;
+
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.controller.response.CourseListResponse;
 import com.lxp.controller.response.CourseRegisterResponse;
+import com.lxp.controller.response.CourseSummaryResponse;
 import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
 import com.lxp.service.CourseService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,9 +24,35 @@ public class CourseController {
 		return new CourseRegisterResponse(course.getId());
 	}
 
-	public void findAll() { // not implemented
+	public CourseListResponse findAll() {
+		List<CourseSummaryResponse> courses = courseService.findAll().stream()
+			.map(course -> new CourseSummaryResponse(
+				course.getId(),
+				course.getTitle(),
+				courseService.findInstructorById(course.getInstructorId()).getName()
+			))
+			.toList();
+		return new CourseListResponse(courses);
 	}
 
-	public void findById() { // not implemented
+	public CourseDetailResponse findDetailById(Long id) {
+		Course course = courseService.findDetailById(id);
+		Instructor instructor = courseService.findInstructorById(course.getInstructorId());
+		List<ContentSummaryResponse> contents = courseService.findContentsByCourseId(id).stream()
+			.map(content -> new ContentSummaryResponse(content.getId(), content.getTitle()))
+			.toList();
+
+		return new CourseDetailResponse(
+			course.getId(),
+			course.getTitle(),
+			instructor.getName(),
+			instructor.getIntroduction(),
+			course.getPrice(),
+			course.getLevel().displayName(),
+			course.getDescription(),
+			contents,
+			course.getCreatedAt(),
+			course.getModifiedAt()
+		);
 	}
 }

--- a/src/main/java/com/lxp/controller/response/ContentSummaryResponse.java
+++ b/src/main/java/com/lxp/controller/response/ContentSummaryResponse.java
@@ -1,0 +1,7 @@
+package com.lxp.controller.response;
+
+public record ContentSummaryResponse(
+	Long id,
+	String title
+) {
+}

--- a/src/main/java/com/lxp/controller/response/CourseDetailResponse.java
+++ b/src/main/java/com/lxp/controller/response/CourseDetailResponse.java
@@ -1,0 +1,22 @@
+package com.lxp.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+public record CourseDetailResponse(
+	Long id,
+	String title,
+	String instructorName,
+	String instructorIntroduction,
+	int price,
+	String level,
+	String description,
+	List<ContentSummaryResponse> contents,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
+	public CourseDetailResponse {
+		contents = List.copyOf(Objects.requireNonNullElse(contents, List.of()));
+	}
+}

--- a/src/main/java/com/lxp/controller/response/CourseListResponse.java
+++ b/src/main/java/com/lxp/controller/response/CourseListResponse.java
@@ -1,0 +1,16 @@
+package com.lxp.controller.response;
+
+import java.util.List;
+import java.util.Objects;
+
+public record CourseListResponse(
+	List<CourseSummaryResponse> courses
+) {
+	public CourseListResponse {
+		courses = List.copyOf(Objects.requireNonNullElse(courses, List.of()));
+	}
+
+	public boolean isEmpty() {
+		return courses.isEmpty();
+	}
+}

--- a/src/main/java/com/lxp/controller/response/CourseSummaryResponse.java
+++ b/src/main/java/com/lxp/controller/response/CourseSummaryResponse.java
@@ -1,0 +1,8 @@
+package com.lxp.controller.response;
+
+public record CourseSummaryResponse(
+	Long id,
+	String title,
+	String instructorName
+) {
+}

--- a/src/main/java/com/lxp/service/CourseService.java
+++ b/src/main/java/com/lxp/service/CourseService.java
@@ -1,9 +1,13 @@
 package com.lxp.service;
 
+import java.util.Comparator;
+import java.util.List;
+
 import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
 import com.lxp.domain.Content;
 import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
 import com.lxp.exception.ErrorCode;
 import com.lxp.exception.LxpException;
 import com.lxp.repository.ContentRepository;
@@ -34,6 +38,28 @@ public class CourseService {
 		Course savedCourse = courseRepository.save(course);
 		saveContents(savedCourse.getId(), request);
 		return savedCourse;
+	}
+
+	public List<Course> findAll() {
+		return courseRepository.findAll();
+	}
+
+	public Course findDetailById(Long id) {
+		return courseRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
+	}
+
+	public Instructor findInstructorById(Long id) {
+		return instructorRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR));
+	}
+
+	public List<Content> findContentsByCourseId(Long courseId) {
+		findDetailById(courseId);
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.sorted(Comparator.comparingInt(Content::getSeq))
+			.toList();
 	}
 
 	private void validateContentCount(CourseRegisterRequest request) {

--- a/src/main/java/com/lxp/view/CourseDetailView.java
+++ b/src/main/java/com/lxp/view/CourseDetailView.java
@@ -1,0 +1,97 @@
+package com.lxp.view;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import com.lxp.controller.CourseController;
+import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.view.command.CourseDetailCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+	private final MenuRenderer menuRenderer;
+	private final OutputView outputView;
+	private final CourseController courseController;
+
+	private Long courseId;
+
+	public void run(Long courseId) {
+		this.courseId = courseId;
+		menuRenderer.render(this);
+	}
+
+	@Override
+	public MenuScreen screen() {
+		CourseDetailResponse response = courseController.findDetailById(courseId);
+		return new MenuScreen("강의 상세", createBody(response), List.of(CourseDetailCommand.values()));
+	}
+
+	@Override
+	public CourseDetailCommand parse(int input) {
+		return CourseDetailCommand.from(input);
+	}
+
+	@Override
+	public boolean handle(CourseDetailCommand command) {
+		switch (command) {
+			case UPDATE, DELETE, SELECT_CONTENT -> outputView.printNotImplemented();
+			case BACK -> {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private String createBody(CourseDetailResponse response) {
+		String line = "-".repeat(60);
+		return String.join(System.lineSeparator(),
+			"  강의 id      : %d",
+			"  강의 제목    : %s",
+			"  강사         : %s",
+			"  가격         : %,d원",
+			"  난이도       : %s",
+			"  강의 설명    : %s",
+			"",
+			line,
+			"  강사 소개",
+			line,
+			"  강사         : %s",
+			"  강사 소개    : %s",
+			"",
+			line,
+			"  콘텐츠 목록",
+			line,
+			"",
+			"%s",
+			"",
+			line,
+			"  게시일         : %s",
+			"  마지막 수정일  : %s"
+		).formatted(
+			response.id(),
+			response.title(),
+			response.instructorName(),
+			response.price(),
+			response.level(),
+			response.description(),
+			response.instructorName(),
+			response.instructorIntroduction(),
+			createContentBody(response),
+			response.createdAt().format(DATE_FORMATTER),
+			response.modifiedAt().format(DATE_FORMATTER)
+		);
+	}
+
+	private String createContentBody(CourseDetailResponse response) {
+		return IntStream.range(0, response.contents().size())
+			.mapToObj(index -> "  %d. %s".formatted(index + 1, response.contents().get(index).title()))
+			.reduce((left, right) -> left + System.lineSeparator() + right)
+			.orElse(outputView.muted("  등록된 콘텐츠가 없습니다."));
+	}
+}

--- a/src/main/java/com/lxp/view/CourseListView.java
+++ b/src/main/java/com/lxp/view/CourseListView.java
@@ -1,8 +1,10 @@
 package com.lxp.view;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.lxp.controller.CourseController;
+import com.lxp.controller.response.CourseListResponse;
 import com.lxp.view.command.CourseListCommand;
 
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ public class CourseListView implements MenuStrategy<CourseListCommand> {
 	private final MenuRenderer menuRenderer;
 	private final OutputView outputView;
 	private final CourseController courseController;
+	private final CourseSelectView courseSelectView;
 
 	public void run() {
 		menuRenderer.render(this);
@@ -20,9 +23,10 @@ public class CourseListView implements MenuStrategy<CourseListCommand> {
 
 	@Override
 	public MenuScreen screen() {
+		CourseListResponse response = courseController.findAll();
 		return new MenuScreen(
 			"강의 목록",
-			outputView.muted("  등록된 강의가 없습니다."),
+			createBody(response),
 			List.of(CourseListCommand.values())
 		);
 	}
@@ -36,13 +40,27 @@ public class CourseListView implements MenuStrategy<CourseListCommand> {
 	public boolean handle(CourseListCommand command) {
 		switch (command) {
 			case SELECT -> {
-				courseController.findById();
-				outputView.printNotImplemented();
+				courseSelectView.run();
 			}
 			case BACK -> {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	private String createBody(CourseListResponse response) {
+		if (response.isEmpty()) {
+			return outputView.muted("  등록된 강의가 없습니다.");
+		}
+		return IntStream.range(0, response.courses().size())
+			.mapToObj(index -> "  %d. %s (id: %d, 강사: %s)".formatted(
+				index + 1,
+				response.courses().get(index).title(),
+				response.courses().get(index).id(),
+				response.courses().get(index).instructorName()
+			))
+			.reduce((left, right) -> left + System.lineSeparator() + right)
+			.orElse("");
 	}
 }

--- a/src/main/java/com/lxp/view/CourseSelectView.java
+++ b/src/main/java/com/lxp/view/CourseSelectView.java
@@ -1,0 +1,65 @@
+package com.lxp.view;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import com.lxp.controller.CourseController;
+import com.lxp.controller.response.CourseListResponse;
+import com.lxp.view.command.CourseSelectCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CourseSelectView implements MenuStrategy<CourseSelectCommand> {
+
+	private final MenuRenderer menuRenderer;
+	private final OutputView outputView;
+	private final CourseController courseController;
+	private final CourseDetailView courseDetailView;
+
+	public void run() {
+		menuRenderer.render(this);
+	}
+
+	@Override
+	public MenuScreen screen() {
+		CourseListResponse response = courseController.findAll();
+		return new MenuScreen("강의 선택", createBody(response), List.of());
+	}
+
+	@Override
+	public CourseSelectCommand parse(int input) {
+		return CourseSelectCommand.from(input);
+	}
+
+	@Override
+	public boolean handle(CourseSelectCommand command) {
+		if (command.isBack()) {
+			return false;
+		}
+		courseDetailView.run(command.courseId());
+		return false;
+	}
+
+	private String createBody(CourseListResponse response) {
+		String baseBody = "%s%n%s";
+		if (response.isEmpty()) {
+			return baseBody.formatted(
+				outputView.muted("  등록된 강의가 없습니다."),
+				outputView.muted("  선택할 강의 id를 입력하세요. (0: 뒤로 가기)")
+			);
+		}
+		return baseBody.formatted(
+			IntStream.range(0, response.courses().size())
+				.mapToObj(index -> "  %d. %s (id: %d, 강사: %s)".formatted(
+					index + 1,
+					response.courses().get(index).title(),
+					response.courses().get(index).id(),
+					response.courses().get(index).instructorName()
+				))
+				.reduce((left, right) -> left + System.lineSeparator() + right)
+				.orElse(""),
+			outputView.muted("  선택할 강의 id를 입력하세요. (0: 뒤로 가기)")
+		);
+	}
+}

--- a/src/main/java/com/lxp/view/CourseView.java
+++ b/src/main/java/com/lxp/view/CourseView.java
@@ -39,7 +39,6 @@ public class CourseView implements MenuStrategy<CourseCommand> {
 		switch (command) {
 			case REGISTER -> registerCourse();
 			case LIST -> {
-				courseController.findAll();
 				courseListView.run();
 			}
 			case BACK -> {

--- a/src/main/java/com/lxp/view/command/CourseDetailCommand.java
+++ b/src/main/java/com/lxp/view/command/CourseDetailCommand.java
@@ -1,0 +1,29 @@
+package com.lxp.view.command;
+
+import java.util.Arrays;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseDetailCommand implements MenuCommand {
+
+	UPDATE(1, "강의 수정"),
+	DELETE(2, "강의 삭제"),
+	SELECT_CONTENT(3, "콘텐츠 선택"),
+	BACK(4, "뒤로 가기");
+
+	private final int value;
+	private final String label;
+
+	public static CourseDetailCommand from(int value) {
+		return Arrays.stream(values())
+			.filter(command -> command.value == value)
+			.findFirst()
+			.orElseThrow(() -> new LxpException(ErrorCode.INVALID_INPUT));
+	}
+}

--- a/src/main/java/com/lxp/view/command/CourseSelectCommand.java
+++ b/src/main/java/com/lxp/view/command/CourseSelectCommand.java
@@ -1,0 +1,38 @@
+package com.lxp.view.command;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public class CourseSelectCommand implements MenuCommand {
+
+	private final int input;
+
+	private CourseSelectCommand(int input) {
+		this.input = input;
+	}
+
+	public static CourseSelectCommand from(int input) {
+		if (input < 0) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+		return new CourseSelectCommand(input);
+	}
+
+	public boolean isBack() {
+		return input == 0;
+	}
+
+	public Long courseId() {
+		return (long)input;
+	}
+
+	@Override
+	public int getValue() {
+		return 0;
+	}
+
+	@Override
+	public String getLabel() {
+		return "뒤로 가기";
+	}
+}

--- a/src/test/java/com/lxp/controller/CourseControllerTest.java
+++ b/src/test/java/com/lxp/controller/CourseControllerTest.java
@@ -3,6 +3,7 @@ package com.lxp.controller;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +15,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.controller.response.CourseListResponse;
 import com.lxp.controller.response.CourseRegisterResponse;
+import com.lxp.domain.Content;
 import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
+import com.lxp.domain.enums.ContentType;
 import com.lxp.domain.enums.Level;
 import com.lxp.service.CourseService;
 
@@ -46,5 +52,48 @@ class CourseControllerTest {
 		CourseRegisterResponse response = courseController.register(request);
 
 		assertThat(response.id()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의 목록을 조회한다")
+	void findAll() {
+		when(courseService.findAll()).thenReturn(List.of(
+			Course.createWithId(1L, 2L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		));
+		when(courseService.findInstructorById(2L)).thenReturn(Instructor.createWithId(2L, "김남준", "자바 강사"));
+
+		CourseListResponse response = courseController.findAll();
+
+		assertThat(response.courses()).hasSize(1);
+		assertThat(response.courses().get(0).title()).isEqualTo("Java 입문");
+		assertThat(response.courses().get(0).instructorName()).isEqualTo("김남준");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의 상세 조회 시 강사 정보와 콘텐츠 목록을 함께 반환한다")
+	void findDetailById() {
+		when(courseService.findDetailById(1L)).thenReturn(Course.createWithId(
+			1L,
+			2L,
+			"Java 입문",
+			"기초 문법",
+			10000,
+			Level.LOW,
+			LocalDateTime.of(2025, 3, 10, 0, 0),
+			LocalDateTime.of(2025, 4, 1, 0, 0)
+		));
+		when(courseService.findInstructorById(2L)).thenReturn(Instructor.createWithId(2L, "김남준", "자바 강사"));
+		when(courseService.findContentsByCourseId(1L)).thenReturn(List.of(
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1)
+		));
+
+		CourseDetailResponse response = courseController.findDetailById(1L);
+
+		assertThat(response.id()).isEqualTo(1L);
+		assertThat(response.instructorName()).isEqualTo("김남준");
+		assertThat(response.instructorIntroduction()).isEqualTo("자바 강사");
+		assertThat(response.contents()).hasSize(1);
+		assertThat(response.contents().get(0).title()).isEqualTo("원시타입");
+		assertThat(response.level()).isEqualTo("입문");
 	}
 }

--- a/src/test/java/com/lxp/service/CourseServiceTest.java
+++ b/src/test/java/com/lxp/service/CourseServiceTest.java
@@ -3,7 +3,9 @@ package com.lxp.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -182,5 +184,69 @@ class CourseServiceTest {
 			.isInstanceOf(LxpException.class)
 			.hasMessage(ErrorCode.COURSE_CONTENT_COUNT_OUT_OF_RANGE.getMessage());
 		verifyNoInteractions(instructorRepository, courseRepository, contentRepository);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의 목록을 조회한다")
+	void findAll() {
+		List<Course> courses = List.of(
+			Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		);
+		when(courseRepository.findAll()).thenReturn(courses);
+
+		List<Course> result = courseService.findAll();
+
+		assertThat(result).extracting(Course::getId, Course::getTitle)
+			.containsExactly(tuple(1L, "Java 입문"));
+	}
+
+	@Test
+	@DisplayName("성공 - 강의 상세를 조회한다")
+	void findDetailById() {
+		Course course = Course.createWithId(
+			1L,
+			1L,
+			"Java 입문",
+			"기초 문법",
+			10000,
+			Level.LOW,
+			LocalDateTime.of(2025, 3, 10, 0, 0),
+			LocalDateTime.of(2025, 4, 1, 0, 0)
+		);
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+
+		Course result = courseService.findDetailById(1L);
+
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getTitle()).isEqualTo("Java 입문");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의의 강사 정보를 조회한다")
+	void findInstructorById() {
+		when(instructorRepository.findById(1L)).thenReturn(Optional.of(Instructor.createWithId(1L, "김남준", "소개")));
+
+		Instructor result = courseService.findInstructorById(1L);
+
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getName()).isEqualTo("김남준");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의의 콘텐츠 목록을 순서대로 조회한다")
+	void findContentsByCourseId() {
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(
+			Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		));
+		when(contentRepository.findAll()).thenReturn(List.of(
+			Content.createWithId(2L, 1L, "for 문", "설명", ContentType.TEXT, 2),
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1),
+			Content.createWithId(3L, 2L, "JPA", "설명", ContentType.TEXT, 1)
+		));
+
+		List<Content> result = courseService.findContentsByCourseId(1L);
+
+		assertThat(result).extracting(Content::getTitle)
+			.containsExactly("원시타입", "for 문");
 	}
 }

--- a/src/test/java/com/lxp/view/CourseDetailViewTest.java
+++ b/src/test/java/com/lxp/view/CourseDetailViewTest.java
@@ -1,0 +1,89 @@
+package com.lxp.view;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.CourseController;
+import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.view.command.CourseDetailCommand;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseDetailView 테스트")
+class CourseDetailViewTest {
+
+	@Mock
+	private MenuRenderer menuRenderer;
+
+	@Mock
+	private OutputView outputView;
+
+	@Mock
+	private CourseController courseController;
+
+	@InjectMocks
+	private CourseDetailView courseDetailView;
+
+	@Test
+	@DisplayName("성공 - 강의 상세 화면 본문에 강사 정보와 콘텐츠 목록을 출력한다")
+	void screen() {
+		courseDetailView.run(1L);
+		when(courseController.findDetailById(1L)).thenReturn(new CourseDetailResponse(
+			1L,
+			"자바의 정석",
+			"김남준",
+			"10년 경력의 자바 전문 강사입니다.",
+			100000,
+			"입문",
+			"자바 기초부터 심화까지 다루는 강의입니다.",
+			List.of(
+				new ContentSummaryResponse(1L, "원시타입"),
+				new ContentSummaryResponse(2L, "for 문")
+			),
+			LocalDateTime.of(2025, 3, 10, 0, 0),
+			LocalDateTime.of(2025, 4, 1, 0, 0)
+		));
+
+		MenuScreen screen = courseDetailView.screen();
+
+		assertThat(screen.title()).isEqualTo("강의 상세");
+		assertThat(screen.body()).contains(
+			"강의 id      : 1",
+			"강의 제목    : 자바의 정석",
+			"강사         : 김남준",
+			"강사 소개    : 10년 경력의 자바 전문 강사입니다.",
+			"1. 원시타입",
+			"2. for 문",
+			"게시일         : 2025.03.10",
+			"마지막 수정일  : 2025.04.01"
+		);
+	}
+
+	@Test
+	@DisplayName("성공 - 미구현 메뉴 선택 시 안내 문구를 출력한다")
+	void handle_notImplemented() {
+		boolean result = courseDetailView.handle(CourseDetailCommand.UPDATE);
+
+		verify(outputView).printNotImplemented();
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("성공 - BACK 처리 시 현재 화면을 종료한다")
+	void handle_back() {
+		boolean result = courseDetailView.handle(CourseDetailCommand.BACK);
+
+		verifyNoInteractions(outputView);
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/com/lxp/view/CourseListViewTest.java
+++ b/src/test/java/com/lxp/view/CourseListViewTest.java
@@ -1,0 +1,87 @@
+package com.lxp.view;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.CourseController;
+import com.lxp.controller.response.CourseListResponse;
+import com.lxp.controller.response.CourseSummaryResponse;
+import com.lxp.view.command.CourseListCommand;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseListView 테스트")
+class CourseListViewTest {
+
+	@Mock
+	private MenuRenderer menuRenderer;
+
+	@Mock
+	private OutputView outputView;
+
+	@Mock
+	private CourseController courseController;
+
+	@Mock
+	private CourseSelectView courseSelectView;
+
+	@InjectMocks
+	private CourseListView courseListView;
+
+	@Test
+	@DisplayName("성공 - 등록된 강의가 없으면 빈 상태 문구를 출력한다")
+	void screen_empty() {
+		when(courseController.findAll()).thenReturn(new CourseListResponse(List.of()));
+		when(outputView.muted("  등록된 강의가 없습니다.")).thenReturn("muted");
+
+		MenuScreen screen = courseListView.screen();
+
+		assertThat(screen.body()).isEqualTo("muted");
+	}
+
+	@Test
+	@DisplayName("성공 - SELECT 처리 시 강의 선택 화면으로 이동한다")
+	void handle_select() {
+		boolean result = courseListView.handle(CourseListCommand.SELECT);
+
+		verify(courseSelectView).run();
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("성공 - BACK 처리 시 현재 화면을 종료한다")
+	void handle_back() {
+		boolean result = courseListView.handle(CourseListCommand.BACK);
+
+		verifyNoInteractions(courseController, courseSelectView);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("성공 - 등록된 강의가 있으면 목록 본문에 강의와 강사를 출력한다")
+	void screen_withCourses() {
+		when(courseController.findAll()).thenReturn(new CourseListResponse(List.of(
+			new CourseSummaryResponse(1L, "Java 입문", "김남준"),
+			new CourseSummaryResponse(2L, "스프링 실전", "홍길동")
+		)));
+
+		MenuScreen screen = courseListView.screen();
+
+		assertThat(screen.body()).contains(
+			"1. Java 입문",
+			"id: 1",
+			"강사: 김남준",
+			"2. 스프링 실전",
+			"id: 2",
+			"강사: 홍길동"
+		);
+	}
+}

--- a/src/test/java/com/lxp/view/CourseSelectViewTest.java
+++ b/src/test/java/com/lxp/view/CourseSelectViewTest.java
@@ -1,0 +1,83 @@
+package com.lxp.view;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.CourseController;
+import com.lxp.controller.response.CourseListResponse;
+import com.lxp.controller.response.CourseSummaryResponse;
+import com.lxp.view.command.CourseSelectCommand;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseSelectView 테스트")
+class CourseSelectViewTest {
+
+	@Mock
+	private MenuRenderer menuRenderer;
+
+	@Mock
+	private OutputView outputView;
+
+	@Mock
+	private CourseController courseController;
+
+	@Mock
+	private CourseDetailView courseDetailView;
+
+	@InjectMocks
+	private CourseSelectView courseSelectView;
+
+	@Test
+	@DisplayName("성공 - 등록된 강의가 있으면 목록 본문에 강의와 강사를 출력한다")
+	void screen_withCourses() {
+		CourseListResponse response = new CourseListResponse(List.of(
+			new CourseSummaryResponse(1L, "Java 입문", "홍길동"),
+			new CourseSummaryResponse(2L, "스프링 실전", "김남준")
+		));
+		when(courseController.findAll()).thenReturn(response);
+		when(outputView.muted("  선택할 강의 id를 입력하세요. (0: 뒤로 가기)")).thenReturn("guide");
+
+		MenuScreen screen = courseSelectView.screen();
+
+		assertThat(screen.body()).contains("1. Java 입문", "강사: 홍길동", "2. 스프링 실전", "guide");
+	}
+
+	@Test
+	@DisplayName("성공 - 등록된 강의가 없으면 빈 상태 문구를 출력한다")
+	void screen_empty() {
+		when(courseController.findAll()).thenReturn(new CourseListResponse(List.of()));
+		when(outputView.muted("  등록된 강의가 없습니다.")).thenReturn("empty");
+		when(outputView.muted("  선택할 강의 id를 입력하세요. (0: 뒤로 가기)")).thenReturn("guide");
+
+		MenuScreen screen = courseSelectView.screen();
+
+		assertThat(screen.body()).isEqualTo("empty\nguide");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의를 선택하면 상세 화면으로 이동한다")
+	void handle_select() {
+		boolean result = courseSelectView.handle(CourseSelectCommand.from(2));
+
+		verify(courseDetailView).run(2L);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("성공 - 0 입력 시 이전 화면으로 돌아간다")
+	void handle_back() {
+		boolean result = courseSelectView.handle(CourseSelectCommand.from(0));
+
+		verifyNoInteractions(courseDetailView);
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/com/lxp/view/CourseViewTest.java
+++ b/src/test/java/com/lxp/view/CourseViewTest.java
@@ -90,7 +90,6 @@ class CourseViewTest {
 		boolean result = courseView.handle(CourseCommand.LIST);
 
 		// then
-		verify(courseController).findAll();
 		verify(courseListView).run();
 		assertThat(result).isTrue();
 	}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #15

## 📌 개요
- 강의 목록 조회와 상세 조회 콘솔 기능을 추가했습니다.
- 강의 상세 화면에서 UI 문서에 맞게 강사 이름과 강사 소개, 콘텐츠 목록을 함께 출력합니다.

## ✨ 변경 사항
- 강의 목록/상세 조회용 response DTO를 추가했습니다.
- CourseService/CourseController에 강의 목록, 상세, 강사, 콘텐츠 조회 흐름을 연결했습니다.
- CourseListView, CourseSelectView, CourseDetailView를 추가 및 연결했습니다.
- 앱 시작 시 실제 조회 확인이 가능하도록 in-memory mock 데이터를 초기화합니다.

## 🔥 변경 이유(선택)
- 강의 등록 후 목록/상세 화면에서 데이터를 확인할 수 있는 조회 흐름이 필요했습니다.

## 🧪 테스트
- [x] 로컬 테스트 완료
- `./gradlew test`
- `./gradlew checkstyleMain checkstyleTest`

## 🤔 고민한 부분 (선택)
- 현재 브랜치는 강의 등록 브랜치 위에 쌓은 stacked branch라 base를 `feature/13-course-registration`로 지정했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모든 강의를 목록으로 조회하는 기능 추가
  * 강의 상세 정보 조회 기능 추가 (강사 정보, 콘텐츠 목록 포함)
  * 강의 선택 및 네비게이션 기능 추가

* **테스트**
  * 강의 컨트롤러, 서비스, 뷰 계층에 대한 포괄적인 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->