### PR TITLE
[feat] 강의 수정 및 삭제 기능 추가

### DIFF
--- a/src/main/java/com/lxp/config/ViewConfig.java
+++ b/src/main/java/com/lxp/config/ViewConfig.java
@@ -50,6 +50,7 @@ public class ViewConfig {
 		);
 		this.courseDetailView = new CourseDetailView(
 			menuRenderer,
+			inputView,
 			outputView,
 			this.controllerConfig.courseController()
 		);

--- a/src/main/java/com/lxp/controller/CourseController.java
+++ b/src/main/java/com/lxp/controller/CourseController.java
@@ -2,12 +2,16 @@ package com.lxp.controller;
 
 import java.util.List;
 
+import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
 import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
 import com.lxp.controller.response.CourseListResponse;
 import com.lxp.controller.response.CourseRegisterResponse;
 import com.lxp.controller.response.CourseSummaryResponse;
+import com.lxp.controller.response.CourseUpdateResponse;
 import com.lxp.domain.Course;
 import com.lxp.domain.Instructor;
 import com.lxp.service.CourseService;
@@ -54,5 +58,15 @@ public class CourseController {
 			course.getCreatedAt(),
 			course.getModifiedAt()
 		);
+	}
+
+	public CourseUpdateResponse update(CourseUpdateRequest request) {
+		Course course = courseService.update(request);
+		return new CourseUpdateResponse(course.getId());
+	}
+
+	public CourseDeleteResponse delete(CourseDeleteRequest request) {
+		Course course = courseService.delete(request);
+		return new CourseDeleteResponse(course.getId());
 	}
 }

--- a/src/main/java/com/lxp/controller/request/CourseDeleteRequest.java
+++ b/src/main/java/com/lxp/controller/request/CourseDeleteRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.controller.request;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public record CourseDeleteRequest(
+	Long id
+) {
+	public CourseDeleteRequest {
+		if (id == null || id <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+	}
+}

--- a/src/main/java/com/lxp/controller/request/CourseUpdateRequest.java
+++ b/src/main/java/com/lxp/controller/request/CourseUpdateRequest.java
@@ -1,0 +1,63 @@
+package com.lxp.controller.request;
+
+import com.lxp.domain.enums.Level;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public record CourseUpdateRequest(
+	Long id,
+	String title,
+	String description,
+	Integer price,
+	Level level
+) {
+
+	public CourseUpdateRequest(
+		Long id,
+		String title,
+		String description,
+		String price,
+		String level
+	) {
+		this(
+			id,
+			normalize(title),
+			normalize(description),
+			parseInt(price),
+			parseLevel(level)
+		);
+	}
+
+	public CourseUpdateRequest {
+		if (id == null || id <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+	}
+
+	private static String normalize(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value;
+	}
+
+	private static Integer parseInt(String value) {
+		String normalizedValue = normalize(value);
+		if (normalizedValue == null) {
+			return null;
+		}
+		try {
+			return Integer.parseInt(normalizedValue);
+		} catch (NumberFormatException e) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+	}
+
+	private static Level parseLevel(String value) {
+		String normalizedValue = normalize(value);
+		if (normalizedValue == null) {
+			return null;
+		}
+		return Level.from(normalizedValue);
+	}
+}

--- a/src/main/java/com/lxp/controller/response/CourseDeleteResponse.java
+++ b/src/main/java/com/lxp/controller/response/CourseDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.lxp.controller.response;
+
+public record CourseDeleteResponse(
+	Long id
+) {
+}

--- a/src/main/java/com/lxp/controller/response/CourseUpdateResponse.java
+++ b/src/main/java/com/lxp/controller/response/CourseUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.lxp.controller.response;
+
+public record CourseUpdateResponse(
+	Long id
+) {
+}

--- a/src/main/java/com/lxp/service/CourseService.java
+++ b/src/main/java/com/lxp/service/CourseService.java
@@ -4,7 +4,9 @@ import java.util.Comparator;
 import java.util.List;
 
 import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
 import com.lxp.domain.Content;
 import com.lxp.domain.Course;
 import com.lxp.domain.Instructor;
@@ -60,6 +62,20 @@ public class CourseService {
 			.filter(content -> content.getCourseId().equals(courseId))
 			.sorted(Comparator.comparingInt(Content::getSeq))
 			.toList();
+	}
+
+	public Course update(CourseUpdateRequest request) {
+		Course course = findDetailById(request.id());
+		course.update(request.title(), request.description(), request.price(), request.level());
+		return courseRepository.save(course);
+	}
+
+	public Course delete(CourseDeleteRequest request) {
+		Course course = findDetailById(request.id());
+		findContentsByCourseId(request.id())
+			.forEach(content -> contentRepository.deleteById(content.getId()));
+		courseRepository.deleteById(request.id());
+		return course;
 	}
 
 	private void validateContentCount(CourseRegisterRequest request) {

--- a/src/main/java/com/lxp/view/CourseDetailView.java
+++ b/src/main/java/com/lxp/view/CourseDetailView.java
@@ -5,7 +5,11 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import com.lxp.controller.CourseController;
+import com.lxp.controller.request.CourseDeleteRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
+import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.controller.response.CourseUpdateResponse;
 import com.lxp.view.command.CourseDetailCommand;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +20,7 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
 	private final MenuRenderer menuRenderer;
+	private final InputView inputView;
 	private final OutputView outputView;
 	private final CourseController courseController;
 
@@ -40,7 +45,12 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 	@Override
 	public boolean handle(CourseDetailCommand command) {
 		switch (command) {
-			case UPDATE, DELETE, SELECT_CONTENT -> outputView.printNotImplemented();
+			case UPDATE -> updateCourse();
+			case DELETE -> {
+				deleteCourse();
+				return false;
+			}
+			case SELECT_CONTENT -> outputView.printNotImplemented();
 			case BACK -> {
 				return false;
 			}
@@ -93,5 +103,46 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 			.mapToObj(index -> "  %d. %s".formatted(index + 1, response.contents().get(index).title()))
 			.reduce((left, right) -> left + System.lineSeparator() + right)
 			.orElse(outputView.muted("  등록된 콘텐츠가 없습니다."));
+	}
+
+	private void updateCourse() {
+		outputView.printHeader("강의 상세 정보 수정");
+		outputView.printBody("  빈 값 입력 시 기존 값이 유지됩니다.");
+		outputView.printSectionLine();
+		outputView.printEmptyLine();
+
+		outputView.printLabel("  강의 제목    : ");
+		String title = inputView.readLine();
+
+		outputView.printLabel("  가격         : ");
+		String price = inputView.readLine();
+
+		outputView.printLabel("  난이도       : ");
+		String level = inputView.readLine();
+
+		outputView.printLabel("  강의 설명    : ");
+		String description = inputView.readLine();
+
+		outputView.printEmptyLine();
+		outputView.printSectionLine();
+
+		CourseUpdateRequest request = new CourseUpdateRequest(
+			courseId,
+			title,
+			description,
+			price,
+			level
+		);
+		CourseUpdateResponse response = courseController.update(request);
+		outputView.printSuccess("  수정되었습니다. id: " + response.id());
+		outputView.printSectionLine();
+	}
+
+	private void deleteCourse() {
+		CourseDeleteRequest request = new CourseDeleteRequest(courseId);
+		CourseDeleteResponse response = courseController.delete(request);
+		outputView.printSectionLine();
+		outputView.printSuccess("  삭제가 완료되었습니다. id: " + response.id());
+		outputView.printSectionLine();
 	}
 }

--- a/src/test/java/com/lxp/controller/CourseControllerTest.java
+++ b/src/test/java/com/lxp/controller/CourseControllerTest.java
@@ -14,10 +14,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
+import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
 import com.lxp.controller.response.CourseListResponse;
 import com.lxp.controller.response.CourseRegisterResponse;
+import com.lxp.controller.response.CourseUpdateResponse;
 import com.lxp.domain.Content;
 import com.lxp.domain.Course;
 import com.lxp.domain.Instructor;
@@ -95,5 +99,29 @@ class CourseControllerTest {
 		assertThat(response.contents()).hasSize(1);
 		assertThat(response.contents().get(0).title()).isEqualTo("원시타입");
 		assertThat(response.level()).isEqualTo("입문");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의를 수정하면 id를 반환한다")
+	void update() {
+		CourseUpdateRequest request = new CourseUpdateRequest(1L, "Java 심화", "심화 문법", "120000", "HIGH");
+		when(courseService.update(request))
+			.thenReturn(Course.createWithId(1L, 1L, "Java 심화", "심화 문법", 120000, Level.HIGH, null, null));
+
+		CourseUpdateResponse response = courseController.update(request);
+
+		assertThat(response.id()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의를 삭제하면 id를 반환한다")
+	void delete() {
+		CourseDeleteRequest request = new CourseDeleteRequest(1L);
+		when(courseService.delete(request))
+			.thenReturn(Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null));
+
+		CourseDeleteResponse response = courseController.delete(request);
+
+		assertThat(response.id()).isEqualTo(1L);
 	}
 }

--- a/src/test/java/com/lxp/controller/request/CourseDeleteRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/CourseDeleteRequestTest.java
@@ -26,4 +26,12 @@ class CourseDeleteRequestTest {
 			.isInstanceOf(LxpException.class)
 			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
 	}
+
+	@Test
+	@DisplayName("실패 - id가 null이면 예외가 발생한다")
+	void create_nullId() {
+		assertThatThrownBy(() -> new CourseDeleteRequest(null))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
 }

--- a/src/test/java/com/lxp/controller/request/CourseDeleteRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/CourseDeleteRequestTest.java
@@ -1,0 +1,29 @@
+package com.lxp.controller.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+@DisplayName("CourseDeleteRequest 테스트")
+class CourseDeleteRequestTest {
+
+	@Test
+	@DisplayName("성공 - 강의 id를 담는다")
+	void create() {
+		CourseDeleteRequest request = new CourseDeleteRequest(1L);
+
+		assertThat(request.id()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("실패 - id가 0이면 예외가 발생한다")
+	void create_invalidId() {
+		assertThatThrownBy(() -> new CourseDeleteRequest(0L))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+}

--- a/src/test/java/com/lxp/controller/request/CourseUpdateRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/CourseUpdateRequestTest.java
@@ -39,4 +39,12 @@ class CourseUpdateRequestTest {
 			.isInstanceOf(LxpException.class)
 			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
 	}
+
+	@Test
+	@DisplayName("실패 - 난이도가 유효하지 않으면 예외가 발생한다")
+	void create_invalidLevel() {
+		assertThatThrownBy(() -> new CourseUpdateRequest(1L, "", "", "", "expert"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_LEVEL.getMessage());
+	}
 }

--- a/src/test/java/com/lxp/controller/request/CourseUpdateRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/CourseUpdateRequestTest.java
@@ -1,0 +1,42 @@
+package com.lxp.controller.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.domain.enums.Level;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+@DisplayName("CourseUpdateRequest 테스트")
+class CourseUpdateRequestTest {
+
+	@Test
+	@DisplayName("성공 - 빈 값은 null로 정규화하고 입력값은 타입으로 변환한다")
+	void create() {
+		CourseUpdateRequest request = new CourseUpdateRequest(1L, "Java 심화", "  ", "120000", "MIDDLE");
+
+		assertThat(request.id()).isEqualTo(1L);
+		assertThat(request.title()).isEqualTo("Java 심화");
+		assertThat(request.description()).isNull();
+		assertThat(request.price()).isEqualTo(120000);
+		assertThat(request.level()).isEqualTo(Level.MIDDLE);
+	}
+
+	@Test
+	@DisplayName("실패 - id가 null이면 예외가 발생한다")
+	void create_nullId() {
+		assertThatThrownBy(() -> new CourseUpdateRequest(null, "", "", "", ""))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - 가격이 숫자가 아니면 예외가 발생한다")
+	void create_invalidPrice() {
+		assertThatThrownBy(() -> new CourseUpdateRequest(1L, "", "", "abc", ""))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+}

--- a/src/test/java/com/lxp/service/CourseServiceTest.java
+++ b/src/test/java/com/lxp/service/CourseServiceTest.java
@@ -273,6 +273,36 @@ class CourseServiceTest {
 	}
 
 	@Test
+	@DisplayName("성공 - 빈 값으로 강의를 수정하면 기존 값이 유지된다")
+	void update_keepExistingValuesWhenFieldsAreBlank() {
+		Course course = Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null);
+		CourseUpdateRequest request = new CourseUpdateRequest(1L, "", "  ", "", "");
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+		when(courseRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Course response = courseService.update(request);
+
+		assertThat(response.getInstructorId()).isEqualTo(1L);
+		assertThat(response.getTitle()).isEqualTo("Java 입문");
+		assertThat(response.getDescription()).isEqualTo("기초 문법");
+		assertThat(response.getPrice()).isEqualTo(10000);
+		assertThat(response.getLevel()).isEqualTo(Level.LOW);
+		verify(courseRepository).save(course);
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 강의를 수정하면 예외가 발생한다")
+	void update_failWhenCourseNotFound() {
+		CourseUpdateRequest request = new CourseUpdateRequest(99L, "Java 심화", "심화 문법", "120000", "HIGH");
+		when(courseRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> courseService.update(request))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_COURSE.getMessage());
+		verify(courseRepository, never()).save(any());
+	}
+
+	@Test
 	@DisplayName("성공 - 강의를 삭제하면 소속 콘텐츠도 함께 삭제한다")
 	void delete() {
 		Course course = Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null);
@@ -290,6 +320,18 @@ class CourseServiceTest {
 		verify(contentRepository).deleteById(2L);
 		verify(contentRepository, never()).deleteById(3L);
 		verify(courseRepository).deleteById(1L);
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 강의를 삭제하면 예외가 발생한다")
+	void delete_failWhenCourseNotFound() {
+		when(courseRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> courseService.delete(new CourseDeleteRequest(99L)))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_COURSE.getMessage());
+		verifyNoInteractions(contentRepository);
+		verify(courseRepository, never()).deleteById(any());
 	}
 
 }

--- a/src/test/java/com/lxp/service/CourseServiceTest.java
+++ b/src/test/java/com/lxp/service/CourseServiceTest.java
@@ -16,7 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
 import com.lxp.domain.Content;
 import com.lxp.domain.Course;
 import com.lxp.domain.Instructor;
@@ -249,4 +251,45 @@ class CourseServiceTest {
 		assertThat(result).extracting(Content::getTitle)
 			.containsExactly("원시타입", "for 문");
 	}
+
+	@Test
+	@DisplayName("성공 - 강의를 수정한다")
+	void update() {
+		Course course = Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null);
+		CourseUpdateRequest request = new CourseUpdateRequest(1L, "Java 심화", "심화 문법", "120000", "HIGH");
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+		when(courseRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Course response = courseService.update(request);
+
+		ArgumentCaptor<Course> captor = ArgumentCaptor.forClass(Course.class);
+		verify(courseRepository).save(captor.capture());
+		assertThat(response.getInstructorId()).isEqualTo(1L);
+		assertThat(response.getTitle()).isEqualTo("Java 심화");
+		assertThat(response.getDescription()).isEqualTo("심화 문법");
+		assertThat(response.getPrice()).isEqualTo(120000);
+		assertThat(response.getLevel()).isEqualTo(Level.HIGH);
+		assertThat(captor.getValue().getInstructorId()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의를 삭제하면 소속 콘텐츠도 함께 삭제한다")
+	void delete() {
+		Course course = Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null);
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+		when(contentRepository.findAll()).thenReturn(List.of(
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1),
+			Content.createWithId(2L, 1L, "for 문", "설명", ContentType.TEXT, 2),
+			Content.createWithId(3L, 2L, "JPA", "설명", ContentType.TEXT, 1)
+		));
+
+		Course response = courseService.delete(new CourseDeleteRequest(1L));
+
+		assertThat(response.getId()).isEqualTo(1L);
+		verify(contentRepository).deleteById(1L);
+		verify(contentRepository).deleteById(2L);
+		verify(contentRepository, never()).deleteById(3L);
+		verify(courseRepository).deleteById(1L);
+	}
+
 }

--- a/src/test/java/com/lxp/view/CourseDetailViewTest.java
+++ b/src/test/java/com/lxp/view/CourseDetailViewTest.java
@@ -14,8 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.lxp.controller.CourseController;
+import com.lxp.controller.request.CourseDeleteRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
 import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
+import com.lxp.controller.response.CourseUpdateResponse;
 import com.lxp.view.command.CourseDetailCommand;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +28,9 @@ class CourseDetailViewTest {
 
 	@Mock
 	private MenuRenderer menuRenderer;
+
+	@Mock
+	private InputView inputView;
 
 	@Mock
 	private OutputView outputView;
@@ -70,9 +77,43 @@ class CourseDetailViewTest {
 	}
 
 	@Test
-	@DisplayName("성공 - 미구현 메뉴 선택 시 안내 문구를 출력한다")
-	void handle_notImplemented() {
+	@DisplayName("성공 - UPDATE 처리 시 입력을 받아 수정 후 성공 문구를 출력한다")
+	void handle_update() {
+		courseDetailView.run(1L);
+		when(inputView.readLine()).thenReturn("Java 심화", "120000", "HIGH", "심화 문법");
+		when(courseController.update(new CourseUpdateRequest(1L, "Java 심화", "심화 문법", "120000", "HIGH")))
+			.thenReturn(new CourseUpdateResponse(1L));
+
 		boolean result = courseDetailView.handle(CourseDetailCommand.UPDATE);
+
+		verify(outputView).printHeader("강의 상세 정보 수정");
+		verify(outputView).printBody("  빈 값 입력 시 기존 값이 유지됩니다.");
+		verify(outputView).printLabel("  강의 제목    : ");
+		verify(outputView).printLabel("  가격         : ");
+		verify(outputView).printLabel("  난이도       : ");
+		verify(outputView).printLabel("  강의 설명    : ");
+		verify(courseController).update(new CourseUpdateRequest(1L, "Java 심화", "심화 문법", "120000", "HIGH"));
+		verify(outputView).printSuccess("  수정되었습니다. id: 1");
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("성공 - DELETE 처리 시 삭제 후 화면을 종료한다")
+	void handle_delete() {
+		courseDetailView.run(1L);
+		when(courseController.delete(new CourseDeleteRequest(1L))).thenReturn(new CourseDeleteResponse(1L));
+
+		boolean result = courseDetailView.handle(CourseDetailCommand.DELETE);
+
+		verify(courseController).delete(new CourseDeleteRequest(1L));
+		verify(outputView).printSuccess("  삭제가 완료되었습니다. id: 1");
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 선택은 아직 구현 예정 안내 문구를 출력한다")
+	void handle_selectContent() {
+		boolean result = courseDetailView.handle(CourseDetailCommand.SELECT_CONTENT);
 
 		verify(outputView).printNotImplemented();
 		assertThat(result).isTrue();


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #17

## 📌 개요
- 강의 상세 화면에서 강의 수정과 삭제를 수행할 수 있도록 기능을 추가했습니다.
- 강의 삭제 시 소속 콘텐츠도 함께 soft delete 처리합니다.

## ✨ 변경 사항
- 강의 수정/삭제 request, response DTO를 추가했습니다.
- CourseService와 CourseController에 수정/삭제 유즈케이스를 추가했습니다.
- CourseDetailView의 강의 수정/삭제 메뉴를 실제 기능에 연결했습니다.
- 강의 수정에서는 강사 ID 변경을 지원하지 않고 제목, 가격, 난이도, 설명만 수정합니다.

## 🔥 변경 이유(선택)
- 강의 상세 화면의 수정/삭제 메뉴가 실제 동작하도록 연결하기 위해 추가했습니다.

## 🧪 테스트
- [x] 로컬 테스트 완료
- `./gradlew test`
- `./gradlew checkstyleMain checkstyleTest`

## 🤔 고민한 부분 (선택)
- 삭제는 현재 Phase 1 in-memory 구조에서 강의와 소속 콘텐츠를 순차적으로 soft delete 처리했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 강좌 수정 기능 추가 — 제목, 설명, 가격, 난이도를 수정하고 성공 메시지로 변경된 강좌 ID를 확인할 수 있습니다.
  * 강좌 삭제 기능 추가 — 강좌와 해당 강좌의 연관 콘텐츠를 함께 삭제하고 삭제된 강좌 ID를 확인할 수 있습니다.

* **Tests**
  * 수정·삭제 흐름과 입력 검증에 대한 단위·통합 테스트가 추가되어 동작과 예외 처리를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->