### PR TITLE
[feat] 콘텐츠 관리 기능 추가

### DIFF
--- a/src/main/java/com/lxp/config/ControllerConfig.java
+++ b/src/main/java/com/lxp/config/ControllerConfig.java
@@ -1,20 +1,27 @@
 package com.lxp.config;
 
+import com.lxp.controller.ContentController;
 import com.lxp.controller.CourseController;
 import com.lxp.controller.InstructorController;
 
 public class ControllerConfig {
 
 	private final CourseController courseController;
+	private final ContentController contentController;
 	private final InstructorController instructorController;
 
 	public ControllerConfig(ServiceConfig serviceConfig) {
 		this.courseController = new CourseController(serviceConfig.courseService());
+		this.contentController = new ContentController(serviceConfig.contentService());
 		this.instructorController = new InstructorController(serviceConfig.instructorService());
 	}
 
 	public CourseController courseController() {
 		return courseController;
+	}
+
+	public ContentController contentController() {
+		return contentController;
 	}
 
 	public InstructorController instructorController() {

--- a/src/main/java/com/lxp/config/ServiceConfig.java
+++ b/src/main/java/com/lxp/config/ServiceConfig.java
@@ -1,11 +1,13 @@
 package com.lxp.config;
 
+import com.lxp.service.ContentService;
 import com.lxp.service.CourseService;
 import com.lxp.service.InstructorService;
 
 public class ServiceConfig {
 
 	private final CourseService courseService;
+	private final ContentService contentService;
 	private final InstructorService instructorService;
 
 	public ServiceConfig(RepositoryConfig repositoryConfig) {
@@ -14,11 +16,19 @@ public class ServiceConfig {
 			repositoryConfig.contentRepository(),
 			repositoryConfig.instructorRepository()
 		);
+		this.contentService = new ContentService(
+			repositoryConfig.courseRepository(),
+			repositoryConfig.contentRepository()
+		);
 		this.instructorService = new InstructorService(repositoryConfig.instructorRepository());
 	}
 
 	public CourseService courseService() {
 		return courseService;
+	}
+
+	public ContentService contentService() {
+		return contentService;
 	}
 
 	public InstructorService instructorService() {

--- a/src/main/java/com/lxp/config/ViewConfig.java
+++ b/src/main/java/com/lxp/config/ViewConfig.java
@@ -2,6 +2,8 @@ package com.lxp.config;
 
 import java.util.Scanner;
 
+import com.lxp.view.ContentDetailView;
+import com.lxp.view.ContentSelectView;
 import com.lxp.view.CourseDetailView;
 import com.lxp.view.CourseListView;
 import com.lxp.view.CourseSelectView;
@@ -26,6 +28,8 @@ public class ViewConfig {
 
 	private final InstructorDetailView instructorDetailView;
 	private final InstructorSelectView instructorSelectView;
+	private final ContentDetailView contentDetailView;
+	private final ContentSelectView contentSelectView;
 	private final CourseDetailView courseDetailView;
 	private final CourseSelectView courseSelectView;
 	private final CourseListView courseListView;
@@ -48,11 +52,25 @@ public class ViewConfig {
 			this.controllerConfig.instructorController(),
 			instructorDetailView
 		);
+		this.contentDetailView = new ContentDetailView(
+			menuRenderer,
+			inputView,
+			outputView,
+			this.controllerConfig.contentController()
+		);
+		this.contentSelectView = new ContentSelectView(
+			menuRenderer,
+			outputView,
+			this.controllerConfig.contentController(),
+			contentDetailView
+		);
 		this.courseDetailView = new CourseDetailView(
 			menuRenderer,
 			inputView,
 			outputView,
-			this.controllerConfig.courseController()
+			this.controllerConfig.courseController(),
+			this.controllerConfig.contentController(),
+			contentSelectView
 		);
 		this.courseSelectView = new CourseSelectView(
 			menuRenderer,

--- a/src/main/java/com/lxp/controller/ContentController.java
+++ b/src/main/java/com/lxp/controller/ContentController.java
@@ -1,0 +1,55 @@
+package com.lxp.controller;
+
+import java.util.List;
+
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.controller.response.ContentDeleteResponse;
+import com.lxp.controller.response.ContentDetailResponse;
+import com.lxp.controller.response.ContentListResponse;
+import com.lxp.controller.response.ContentRegisterResponse;
+import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.controller.response.ContentUpdateResponse;
+import com.lxp.domain.Content;
+import com.lxp.service.ContentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentController {
+
+	private final ContentService contentService;
+
+	public ContentRegisterResponse register(ContentRegisterRequest request) {
+		Content content = contentService.register(request);
+		return new ContentRegisterResponse(content.getId());
+	}
+
+	public ContentListResponse findAllByCourseId(Long courseId) {
+		List<ContentSummaryResponse> contents = contentService.findAllByCourseId(courseId).stream()
+			.map(content -> new ContentSummaryResponse(content.getId(), content.getTitle()))
+			.toList();
+		return new ContentListResponse(contents);
+	}
+
+	public ContentDetailResponse findDetailById(Long id) {
+		Content content = contentService.findDetailById(id);
+		return new ContentDetailResponse(
+			content.getId(),
+			content.getTitle(),
+			content.getBody(),
+			content.getContentType().name()
+		);
+	}
+
+	public ContentUpdateResponse update(ContentUpdateRequest request) {
+		Content content = contentService.update(request);
+		return new ContentUpdateResponse(content.getId());
+	}
+
+	public ContentDeleteResponse delete(ContentDeleteRequest request) {
+		Content content = contentService.delete(request);
+		return new ContentDeleteResponse(content.getId());
+	}
+}

--- a/src/main/java/com/lxp/controller/request/ContentDeleteRequest.java
+++ b/src/main/java/com/lxp/controller/request/ContentDeleteRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.controller.request;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public record ContentDeleteRequest(
+	Long id
+) {
+	public ContentDeleteRequest {
+		if (id == null || id <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+	}
+}

--- a/src/main/java/com/lxp/controller/request/ContentRegisterRequest.java
+++ b/src/main/java/com/lxp/controller/request/ContentRegisterRequest.java
@@ -14,7 +14,14 @@ public record ContentRegisterRequest(Long courseId, String title, String body, C
 		this(courseId, title, body, ContentType.TEXT);
 	}
 
+	public ContentRegisterRequest(Long courseId, String title, String body, String contentType) {
+		this(courseId, title, body, ContentType.from(contentType));
+	}
+
 	public ContentRegisterRequest {
+		if (courseId != null) {
+			Assert.isTrue(courseId > 0, ErrorCode.INVALID_INPUT);
+		}
 		Assert.notEmpty(title, ErrorCode.INVALID_INPUT);
 		Assert.notEmpty(body, ErrorCode.INVALID_INPUT);
 		Assert.notNull(contentType, ErrorCode.INVALID_INPUT);

--- a/src/main/java/com/lxp/controller/request/ContentUpdateRequest.java
+++ b/src/main/java/com/lxp/controller/request/ContentUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.lxp.controller.request;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public record ContentUpdateRequest(
+	Long id,
+	String title,
+	String body
+) {
+
+	public ContentUpdateRequest {
+		if (id == null || id <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+		title = normalize(title);
+		body = normalize(body);
+	}
+
+	private static String normalize(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/lxp/controller/response/ContentDeleteResponse.java
+++ b/src/main/java/com/lxp/controller/response/ContentDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.lxp.controller.response;
+
+public record ContentDeleteResponse(
+	Long id
+) {
+}

--- a/src/main/java/com/lxp/controller/response/ContentDetailResponse.java
+++ b/src/main/java/com/lxp/controller/response/ContentDetailResponse.java
@@ -1,0 +1,9 @@
+package com.lxp.controller.response;
+
+public record ContentDetailResponse(
+	Long id,
+	String title,
+	String body,
+	String contentType
+) {
+}

--- a/src/main/java/com/lxp/controller/response/ContentListResponse.java
+++ b/src/main/java/com/lxp/controller/response/ContentListResponse.java
@@ -1,0 +1,16 @@
+package com.lxp.controller.response;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ContentListResponse(
+	List<ContentSummaryResponse> contents
+) {
+	public ContentListResponse {
+		contents = List.copyOf(Objects.requireNonNullElse(contents, List.of()));
+	}
+
+	public boolean isEmpty() {
+		return contents.isEmpty();
+	}
+}

--- a/src/main/java/com/lxp/controller/response/ContentUpdateResponse.java
+++ b/src/main/java/com/lxp/controller/response/ContentUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.lxp.controller.response;
+
+public record ContentUpdateResponse(
+	Long id
+) {
+}

--- a/src/main/java/com/lxp/domain/enums/ContentType.java
+++ b/src/main/java/com/lxp/domain/enums/ContentType.java
@@ -1,5 +1,20 @@
 package com.lxp.domain.enums;
 
+import com.lxp.common.validate.Assert;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
 public enum ContentType {
-	VIDEO, TEXT, FILE
+	VIDEO, TEXT, FILE;
+
+	public static ContentType from(String value) {
+		Assert.notEmpty(value, ErrorCode.INVALID_INPUT);
+
+		return switch (value.trim().toUpperCase()) {
+			case "1", "VIDEO" -> VIDEO;
+			case "2", "TEXT" -> TEXT;
+			case "3", "FILE" -> FILE;
+			default -> throw new LxpException(ErrorCode.INVALID_CONTENT_TYPE);
+		};
+	}
 }

--- a/src/main/java/com/lxp/service/ContentService.java
+++ b/src/main/java/com/lxp/service/ContentService.java
@@ -1,0 +1,79 @@
+package com.lxp.service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.domain.Content;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.CourseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentService {
+
+	private final CourseRepository courseRepository;
+	private final ContentRepository contentRepository;
+
+	public Content register(ContentRegisterRequest request) {
+		validateCourseId(request.courseId());
+		Content content = Content.create(
+			request.courseId(),
+			request.title(),
+			request.body(),
+			request.contentType(),
+			nextSeq(request.courseId())
+		);
+		return contentRepository.save(content);
+	}
+
+	public List<Content> findAllByCourseId(Long courseId) {
+		validateCourseId(courseId);
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.sorted(Comparator.comparingInt(Content::getSeq))
+			.toList();
+	}
+
+	public Content findDetailById(Long id) {
+		return getContentOrThrow(id);
+	}
+
+	public Content update(ContentUpdateRequest request) {
+		Content content = getContentOrThrow(request.id());
+		content.update(request.title(), request.body());
+		return contentRepository.save(content);
+	}
+
+	public Content delete(ContentDeleteRequest request) {
+		Content content = getContentOrThrow(request.id());
+		contentRepository.deleteById(request.id());
+		return content;
+	}
+
+	private void validateCourseId(Long courseId) {
+		if (courseId == null || courseId <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+		courseRepository.findById(courseId)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
+	}
+
+	private int nextSeq(Long courseId) {
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.mapToInt(Content::getSeq)
+			.max()
+			.orElse(0) + 1;
+	}
+
+	private Content getContentOrThrow(Long id) {
+		return contentRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_CONTENT));
+	}
+}

--- a/src/main/java/com/lxp/view/ContentDetailView.java
+++ b/src/main/java/com/lxp/view/ContentDetailView.java
@@ -1,0 +1,92 @@
+package com.lxp.view;
+
+import java.util.List;
+
+import com.lxp.controller.ContentController;
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.controller.response.ContentDeleteResponse;
+import com.lxp.controller.response.ContentDetailResponse;
+import com.lxp.controller.response.ContentUpdateResponse;
+import com.lxp.view.command.ContentDetailCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentDetailView implements MenuStrategy<ContentDetailCommand> {
+
+	private final MenuRenderer menuRenderer;
+	private final InputView inputView;
+	private final OutputView outputView;
+	private final ContentController contentController;
+
+	private Long contentId;
+
+	public void run(Long contentId) {
+		this.contentId = contentId;
+		menuRenderer.render(this);
+	}
+
+	@Override
+	public MenuScreen screen() {
+		ContentDetailResponse response = contentController.findDetailById(contentId);
+		return new MenuScreen("콘텐츠 상세", createBody(response), List.of(ContentDetailCommand.values()));
+	}
+
+	@Override
+	public ContentDetailCommand parse(int input) {
+		return ContentDetailCommand.from(input);
+	}
+
+	@Override
+	public boolean handle(ContentDetailCommand command) {
+		switch (command) {
+			case UPDATE -> updateContent();
+			case DELETE -> {
+				deleteContent();
+				return false;
+			}
+			case BACK -> {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private String createBody(ContentDetailResponse response) {
+		return String.join(System.lineSeparator(),
+			"  콘텐츠 제목  : %s",
+			"  콘텐츠 타입  : %s",
+			"  콘텐츠 내용  : %s"
+		).formatted(response.title(), response.contentType(), response.body());
+	}
+
+	private void updateContent() {
+		outputView.printHeader("콘텐츠 수정");
+		outputView.printBody("  빈 값 입력 시 기존 값이 유지됩니다.");
+		outputView.printSectionLine();
+		outputView.printEmptyLine();
+
+		outputView.printLabel("  수정할 제목  : ");
+		String title = inputView.readLine();
+
+		outputView.printLabel("  수정할 내용  : ");
+		String body = inputView.readLine();
+
+		outputView.printEmptyLine();
+		outputView.printSectionLine();
+
+		ContentUpdateRequest request = new ContentUpdateRequest(contentId, title, body);
+		ContentUpdateResponse response = contentController.update(request);
+		outputView.printSuccess("  수정되었습니다. id: " + response.id());
+		outputView.printSectionLine();
+	}
+
+	private void deleteContent() {
+		ContentDeleteRequest request = new ContentDeleteRequest(contentId);
+		ContentDeleteResponse response = contentController.delete(request);
+		outputView.printSectionLine();
+		outputView.printSuccess("  삭제가 완료되었습니다. id: " + response.id());
+		outputView.printSectionLine();
+	}
+}

--- a/src/main/java/com/lxp/view/ContentSelectView.java
+++ b/src/main/java/com/lxp/view/ContentSelectView.java
@@ -1,0 +1,67 @@
+package com.lxp.view;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import com.lxp.controller.ContentController;
+import com.lxp.controller.response.ContentListResponse;
+import com.lxp.view.command.ContentSelectCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentSelectView implements MenuStrategy<ContentSelectCommand> {
+
+	private final MenuRenderer menuRenderer;
+	private final OutputView outputView;
+	private final ContentController contentController;
+	private final ContentDetailView contentDetailView;
+
+	private Long courseId;
+
+	public void run(Long courseId) {
+		this.courseId = courseId;
+		menuRenderer.render(this);
+	}
+
+	@Override
+	public MenuScreen screen() {
+		ContentListResponse response = contentController.findAllByCourseId(courseId);
+		return new MenuScreen("콘텐츠 선택", createBody(response), List.of());
+	}
+
+	@Override
+	public ContentSelectCommand parse(int input) {
+		return ContentSelectCommand.from(input);
+	}
+
+	@Override
+	public boolean handle(ContentSelectCommand command) {
+		if (command.isBack()) {
+			return false;
+		}
+		contentDetailView.run(command.contentId());
+		return false;
+	}
+
+	private String createBody(ContentListResponse response) {
+		String baseBody = "%s%n%s";
+		if (response.isEmpty()) {
+			return baseBody.formatted(
+				outputView.muted("  등록된 콘텐츠가 없습니다."),
+				outputView.muted("  선택할 콘텐츠 id를 입력하세요. (0: 뒤로 가기)")
+			);
+		}
+		return baseBody.formatted(
+			IntStream.range(0, response.contents().size())
+				.mapToObj(index -> "  %d. %s (id: %d)".formatted(
+					index + 1,
+					response.contents().get(index).title(),
+					response.contents().get(index).id()
+				))
+				.reduce((left, right) -> left + System.lineSeparator() + right)
+				.orElse(""),
+			outputView.muted("  선택할 콘텐츠 id를 입력하세요. (0: 뒤로 가기)")
+		);
+	}
+}

--- a/src/main/java/com/lxp/view/CourseDetailView.java
+++ b/src/main/java/com/lxp/view/CourseDetailView.java
@@ -4,9 +4,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.lxp.controller.ContentController;
 import com.lxp.controller.CourseController;
+import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseUpdateRequest;
+import com.lxp.controller.response.ContentRegisterResponse;
 import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
 import com.lxp.controller.response.CourseUpdateResponse;
@@ -23,6 +26,8 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 	private final InputView inputView;
 	private final OutputView outputView;
 	private final CourseController courseController;
+	private final ContentController contentController;
+	private final ContentSelectView contentSelectView;
 
 	private Long courseId;
 
@@ -50,7 +55,8 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 				deleteCourse();
 				return false;
 			}
-			case SELECT_CONTENT -> outputView.printNotImplemented();
+			case REGISTER_CONTENT -> registerContent();
+			case SELECT_CONTENT -> contentSelectView.run(courseId);
 			case BACK -> {
 				return false;
 			}
@@ -143,6 +149,27 @@ public class CourseDetailView implements MenuStrategy<CourseDetailCommand> {
 		CourseDeleteResponse response = courseController.delete(request);
 		outputView.printSectionLine();
 		outputView.printSuccess("  삭제가 완료되었습니다. id: " + response.id());
+		outputView.printSectionLine();
+	}
+
+	private void registerContent() {
+		outputView.printHeader("콘텐츠 등록");
+
+		outputView.printLabel("  콘텐츠 제목  : ");
+		String title = inputView.readLine();
+
+		outputView.printLabel("  콘텐츠 타입(VIDEO/TEXT/FILE)  : ");
+		String contentType = inputView.readLine();
+
+		outputView.printLabel("  콘텐츠 내용  : ");
+		String body = inputView.readLine();
+
+		outputView.printEmptyLine();
+		outputView.printSectionLine();
+
+		ContentRegisterRequest request = new ContentRegisterRequest(courseId, title, body, contentType);
+		ContentRegisterResponse response = contentController.register(request);
+		outputView.printSuccess("  콘텐츠가 등록되었습니다. id: " + response.id());
 		outputView.printSectionLine();
 	}
 }

--- a/src/main/java/com/lxp/view/command/ContentDetailCommand.java
+++ b/src/main/java/com/lxp/view/command/ContentDetailCommand.java
@@ -10,18 +10,16 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum CourseDetailCommand implements MenuCommand {
+public enum ContentDetailCommand implements MenuCommand {
 
-	UPDATE(1, "강의 수정"),
-	DELETE(2, "강의 삭제"),
-	REGISTER_CONTENT(3, "콘텐츠 등록"),
-	SELECT_CONTENT(4, "콘텐츠 선택"),
-	BACK(5, "뒤로 가기");
+	UPDATE(1, "콘텐츠 수정"),
+	DELETE(2, "콘텐츠 삭제"),
+	BACK(3, "뒤로 가기");
 
 	private final int value;
 	private final String label;
 
-	public static CourseDetailCommand from(int value) {
+	public static ContentDetailCommand from(int value) {
 		return Arrays.stream(values())
 			.filter(command -> command.value == value)
 			.findFirst()

--- a/src/main/java/com/lxp/view/command/ContentSelectCommand.java
+++ b/src/main/java/com/lxp/view/command/ContentSelectCommand.java
@@ -1,0 +1,38 @@
+package com.lxp.view.command;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public class ContentSelectCommand implements MenuCommand {
+
+	private final int input;
+
+	private ContentSelectCommand(int input) {
+		this.input = input;
+	}
+
+	public static ContentSelectCommand from(int input) {
+		if (input < 0) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+		return new ContentSelectCommand(input);
+	}
+
+	public boolean isBack() {
+		return input == 0;
+	}
+
+	public Long contentId() {
+		return (long)input;
+	}
+
+	@Override
+	public int getValue() {
+		return 0;
+	}
+
+	@Override
+	public String getLabel() {
+		return "뒤로 가기";
+	}
+}

--- a/src/test/java/com/lxp/controller/ContentControllerTest.java
+++ b/src/test/java/com/lxp/controller/ContentControllerTest.java
@@ -1,0 +1,99 @@
+package com.lxp.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.controller.response.ContentDeleteResponse;
+import com.lxp.controller.response.ContentDetailResponse;
+import com.lxp.controller.response.ContentListResponse;
+import com.lxp.controller.response.ContentRegisterResponse;
+import com.lxp.controller.response.ContentUpdateResponse;
+import com.lxp.domain.Content;
+import com.lxp.domain.enums.ContentType;
+import com.lxp.service.ContentService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContentController 테스트")
+class ContentControllerTest {
+
+	@Mock
+	private ContentService contentService;
+
+	@InjectMocks
+	private ContentController contentController;
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 등록하면 id를 반환한다")
+	void register() {
+		ContentRegisterRequest request = new ContentRegisterRequest(1L, "Stream", "설명", "TEXT");
+		when(contentService.register(request))
+			.thenReturn(Content.createWithId(3L, 1L, "Stream", "설명", ContentType.TEXT, 3));
+
+		ContentRegisterResponse response = contentController.register(request);
+
+		assertThat(response.id()).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의의 콘텐츠 목록을 조회한다")
+	void findAllByCourseId() {
+		when(contentService.findAllByCourseId(1L)).thenReturn(List.of(
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1)
+		));
+
+		ContentListResponse response = contentController.findAllByCourseId(1L);
+
+		assertThat(response.contents()).hasSize(1);
+		assertThat(response.contents().get(0).title()).isEqualTo("원시타입");
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 상세를 조회한다")
+	void findDetailById() {
+		when(contentService.findDetailById(1L))
+			.thenReturn(Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1));
+
+		ContentDetailResponse response = contentController.findDetailById(1L);
+
+		assertThat(response.id()).isEqualTo(1L);
+		assertThat(response.title()).isEqualTo("원시타입");
+		assertThat(response.body()).isEqualTo("설명");
+		assertThat(response.contentType()).isEqualTo("TEXT");
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 수정하면 id를 반환한다")
+	void update() {
+		ContentUpdateRequest request = new ContentUpdateRequest(1L, "Stream", "설명");
+		when(contentService.update(request))
+			.thenReturn(Content.createWithId(1L, 1L, "Stream", "설명", ContentType.TEXT, 1));
+
+		ContentUpdateResponse response = contentController.update(request);
+
+		assertThat(response.id()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 삭제하면 id를 반환한다")
+	void delete() {
+		ContentDeleteRequest request = new ContentDeleteRequest(1L);
+		when(contentService.delete(request))
+			.thenReturn(Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1));
+
+		ContentDeleteResponse response = contentController.delete(request);
+
+		assertThat(response.id()).isEqualTo(1L);
+	}
+}

--- a/src/test/java/com/lxp/controller/request/ContentDeleteRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/ContentDeleteRequestTest.java
@@ -1,0 +1,37 @@
+package com.lxp.controller.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+@DisplayName("ContentDeleteRequest 테스트")
+class ContentDeleteRequestTest {
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 id를 담는다")
+	void create() {
+		ContentDeleteRequest request = new ContentDeleteRequest(1L);
+
+		assertThat(request.id()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("실패 - id가 0이면 예외가 발생한다")
+	void create_invalidId() {
+		assertThatThrownBy(() -> new ContentDeleteRequest(0L))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - id가 null이면 예외가 발생한다")
+	void create_nullId() {
+		assertThatThrownBy(() -> new ContentDeleteRequest(null))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+}

--- a/src/test/java/com/lxp/controller/request/ContentRegisterRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/ContentRegisterRequestTest.java
@@ -22,10 +22,51 @@ class ContentRegisterRequestTest {
 	}
 
 	@Test
+	@DisplayName("성공 - 문자열 콘텐츠 타입 입력을 변환한다")
+	void create_withContentTypeText() {
+		ContentRegisterRequest request = new ContentRegisterRequest(1L, "원시타입", "설명", "1");
+
+		assertThat(request.courseId()).isEqualTo(1L);
+		assertThat(request.contentType()).isEqualTo(ContentType.VIDEO);
+	}
+
+	@Test
+	@DisplayName("실패 - 내용이 공백이면 예외가 발생한다")
+	void create_blankBody() {
+		assertThatThrownBy(() -> new ContentRegisterRequest("원시타입", "   "))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - 콘텐츠 타입이 null이면 예외가 발생한다")
+	void create_nullContentType() {
+		assertThatThrownBy(() -> new ContentRegisterRequest(1L, "원시타입", "설명", (ContentType)null))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
 	@DisplayName("실패 - 제목이 공백이면 예외가 발생한다")
 	void create_blankTitle() {
 		assertThatThrownBy(() -> new ContentRegisterRequest("   ", "설명"))
 			.isInstanceOf(LxpException.class)
 			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - courseId가 0이면 예외가 발생한다")
+	void create_invalidCourseId() {
+		assertThatThrownBy(() -> new ContentRegisterRequest(0L, "원시타입", "설명", "TEXT"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - 콘텐츠 타입 문자열이 유효하지 않으면 예외가 발생한다")
+	void create_invalidContentTypeText() {
+		assertThatThrownBy(() -> new ContentRegisterRequest(1L, "원시타입", "설명", "LINK"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_CONTENT_TYPE.getMessage());
 	}
 }

--- a/src/test/java/com/lxp/controller/request/ContentUpdateRequestTest.java
+++ b/src/test/java/com/lxp/controller/request/ContentUpdateRequestTest.java
@@ -1,0 +1,39 @@
+package com.lxp.controller.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+@DisplayName("ContentUpdateRequest 테스트")
+class ContentUpdateRequestTest {
+
+	@Test
+	@DisplayName("성공 - 빈 값은 null로 정규화한다")
+	void create() {
+		ContentUpdateRequest request = new ContentUpdateRequest(1L, "Stream", "  ");
+
+		assertThat(request.id()).isEqualTo(1L);
+		assertThat(request.title()).isEqualTo("Stream");
+		assertThat(request.body()).isNull();
+	}
+
+	@Test
+	@DisplayName("실패 - id가 null이면 예외가 발생한다")
+	void create_nullId() {
+		assertThatThrownBy(() -> new ContentUpdateRequest(null, "Stream", "설명"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - id가 0이면 예외가 발생한다")
+	void create_invalidId() {
+		assertThatThrownBy(() -> new ContentUpdateRequest(0L, "Stream", "설명"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+}

--- a/src/test/java/com/lxp/domain/enums/ContentTypeTest.java
+++ b/src/test/java/com/lxp/domain/enums/ContentTypeTest.java
@@ -1,0 +1,45 @@
+package com.lxp.domain.enums;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+@DisplayName("ContentType 테스트")
+class ContentTypeTest {
+
+	@Test
+	@DisplayName("성공 - 숫자 입력으로 콘텐츠 타입을 변환한다")
+	void from_numericValue() {
+		assertThat(ContentType.from("1")).isEqualTo(ContentType.VIDEO);
+		assertThat(ContentType.from("2")).isEqualTo(ContentType.TEXT);
+		assertThat(ContentType.from("3")).isEqualTo(ContentType.FILE);
+	}
+
+	@Test
+	@DisplayName("성공 - 문자 입력으로 콘텐츠 타입을 변환한다")
+	void from_textValue() {
+		assertThat(ContentType.from("video")).isEqualTo(ContentType.VIDEO);
+		assertThat(ContentType.from("TEXT")).isEqualTo(ContentType.TEXT);
+		assertThat(ContentType.from("File")).isEqualTo(ContentType.FILE);
+	}
+
+	@Test
+	@DisplayName("실패 - 공백 입력이면 INVALID_INPUT 예외가 발생한다")
+	void from_blankValue() {
+		assertThatThrownBy(() -> ContentType.from("   "))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - 유효하지 않은 값이면 INVALID_CONTENT_TYPE 예외가 발생한다")
+	void from_invalidValue() {
+		assertThatThrownBy(() -> ContentType.from("link"))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.INVALID_CONTENT_TYPE.getMessage());
+	}
+}

--- a/src/test/java/com/lxp/repository/inmemory/InMemoryContentRepositoryTest.java
+++ b/src/test/java/com/lxp/repository/inmemory/InMemoryContentRepositoryTest.java
@@ -25,6 +25,27 @@ class InMemoryContentRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("성공 - id가 있는 콘텐츠를 저장하면 기존 콘텐츠를 수정한다")
+	void save_existingContent() {
+		Content savedContent = contentRepository.save(Content.create(1L, "원시타입", "설명", ContentType.TEXT, 1));
+		Content updatedContent = Content.createWithId(
+			savedContent.getId(),
+			savedContent.getCourseId(),
+			"Stream",
+			"Stream 설명",
+			savedContent.getContentType(),
+			savedContent.getSeq()
+		);
+
+		Content result = contentRepository.save(updatedContent);
+
+		assertThat(result.getId()).isEqualTo(savedContent.getId());
+		assertThat(result.getTitle()).isEqualTo("Stream");
+		assertThat(result.getBody()).isEqualTo("Stream 설명");
+		assertThat(contentRepository.findAll()).hasSize(1);
+	}
+
+	@Test
 	@DisplayName("성공 - 콘텐츠를 삭제하면 soft delete 처리되어 조회되지 않는다")
 	void deleteById() {
 		Content savedContent = contentRepository.save(Content.create(1L, "원시타입", "설명", ContentType.TEXT, 1));

--- a/src/test/java/com/lxp/service/ContentServiceTest.java
+++ b/src/test/java/com/lxp/service/ContentServiceTest.java
@@ -1,0 +1,222 @@
+package com.lxp.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.domain.Content;
+import com.lxp.domain.Course;
+import com.lxp.domain.enums.ContentType;
+import com.lxp.domain.enums.Level;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.CourseRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContentService 테스트")
+class ContentServiceTest {
+
+	@Mock
+	private CourseRepository courseRepository;
+
+	@Mock
+	private ContentRepository contentRepository;
+
+	@InjectMocks
+	private ContentService contentService;
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 등록하면 다음 seq를 부여한다")
+	void register() {
+		ContentRegisterRequest request = new ContentRegisterRequest(1L, "Stream", "설명", "TEXT");
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(
+			Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		));
+		when(contentRepository.findAll()).thenReturn(List.of(
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1),
+			Content.createWithId(2L, 1L, "for 문", "설명", ContentType.TEXT, 2)
+		));
+		when(contentRepository.save(any())).thenAnswer(invocation -> {
+			Content saved = invocation.getArgument(0);
+			return Content.createWithId(
+				3L,
+				saved.getCourseId(),
+				saved.getTitle(),
+				saved.getBody(),
+				saved.getContentType(),
+				saved.getSeq()
+			);
+		});
+
+		Content response = contentService.register(request);
+
+		ArgumentCaptor<Content> captor = ArgumentCaptor.forClass(Content.class);
+		verify(contentRepository).save(captor.capture());
+		assertThat(response.getId()).isEqualTo(3L);
+		assertThat(captor.getValue().getCourseId()).isEqualTo(1L);
+		assertThat(captor.getValue().getTitle()).isEqualTo("Stream");
+		assertThat(captor.getValue().getContentType()).isEqualTo(ContentType.TEXT);
+		assertThat(captor.getValue().getSeq()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("성공 - 다른 강의 콘텐츠는 seq 계산에서 제외한다")
+	void register_excludeOtherCourseContentsWhenCalculatingSeq() {
+		ContentRegisterRequest request = new ContentRegisterRequest(1L, "Stream", "설명", "TEXT");
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(
+			Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		));
+		when(contentRepository.findAll()).thenReturn(List.of(
+			Content.createWithId(1L, 2L, "JPA", "설명", ContentType.TEXT, 7)
+		));
+		when(contentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		contentService.register(request);
+
+		ArgumentCaptor<Content> captor = ArgumentCaptor.forClass(Content.class);
+		verify(contentRepository).save(captor.capture());
+		assertThat(captor.getValue().getSeq()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("성공 - 강의의 콘텐츠 목록을 순서대로 조회한다")
+	void findAllByCourseId() {
+		when(courseRepository.findById(1L)).thenReturn(Optional.of(
+			Course.createWithId(1L, 1L, "Java 입문", "기초 문법", 10000, Level.LOW, null, null)
+		));
+		when(contentRepository.findAll()).thenReturn(List.of(
+			Content.createWithId(2L, 1L, "for 문", "설명", ContentType.TEXT, 2),
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1),
+			Content.createWithId(3L, 2L, "JPA", "설명", ContentType.TEXT, 1)
+		));
+
+		List<Content> result = contentService.findAllByCourseId(1L);
+
+		assertThat(result).extracting(Content::getTitle)
+			.containsExactly("원시타입", "for 문");
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 상세를 조회한다")
+	void findDetailById() {
+		when(contentRepository.findById(1L)).thenReturn(Optional.of(
+			Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1)
+		));
+
+		Content result = contentService.findDetailById(1L);
+
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getTitle()).isEqualTo("원시타입");
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 수정한다")
+	void update() {
+		Content content = Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1);
+		ContentUpdateRequest request = new ContentUpdateRequest(1L, "Stream", "Stream 설명");
+		when(contentRepository.findById(1L)).thenReturn(Optional.of(content));
+		when(contentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Content response = contentService.update(request);
+
+		assertThat(response.getTitle()).isEqualTo("Stream");
+		assertThat(response.getBody()).isEqualTo("Stream 설명");
+		verify(contentRepository).save(content);
+	}
+
+	@Test
+	@DisplayName("성공 - 빈 값으로 콘텐츠를 수정하면 기존 값이 유지된다")
+	void update_keepExistingValuesWhenFieldsAreBlank() {
+		Content content = Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1);
+		ContentUpdateRequest request = new ContentUpdateRequest(1L, "", "  ");
+		when(contentRepository.findById(1L)).thenReturn(Optional.of(content));
+		when(contentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Content response = contentService.update(request);
+
+		assertThat(response.getTitle()).isEqualTo("원시타입");
+		assertThat(response.getBody()).isEqualTo("설명");
+		verify(contentRepository).save(content);
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 삭제한다")
+	void delete() {
+		Content content = Content.createWithId(1L, 1L, "원시타입", "설명", ContentType.TEXT, 1);
+		when(contentRepository.findById(1L)).thenReturn(Optional.of(content));
+
+		Content response = contentService.delete(new ContentDeleteRequest(1L));
+
+		assertThat(response.getId()).isEqualTo(1L);
+		verify(contentRepository).deleteById(1L);
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 강의에 콘텐츠를 등록하면 예외가 발생한다")
+	void register_failWhenCourseNotFound() {
+		ContentRegisterRequest request = new ContentRegisterRequest(99L, "Stream", "설명", "TEXT");
+		when(courseRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contentService.register(request))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_COURSE.getMessage());
+		verifyNoInteractions(contentRepository);
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 강의의 콘텐츠 목록을 조회하면 예외가 발생한다")
+	void findAllByCourseId_failWhenCourseNotFound() {
+		when(courseRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contentService.findAllByCourseId(99L))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_COURSE.getMessage());
+		verifyNoInteractions(contentRepository);
+	}
+
+	@Test
+	@DisplayName("실패 - 콘텐츠 id가 존재하지 않으면 상세 조회 시 예외가 발생한다")
+	void findDetailById_failWhenContentNotFound() {
+		when(contentRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contentService.findDetailById(99L))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_CONTENT.getMessage());
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 콘텐츠를 수정하면 예외가 발생한다")
+	void update_failWhenContentNotFound() {
+		when(contentRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contentService.update(new ContentUpdateRequest(99L, "Stream", "설명")))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_CONTENT.getMessage());
+		verify(contentRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 콘텐츠를 삭제하면 예외가 발생한다")
+	void delete_failWhenContentNotFound() {
+		when(contentRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contentService.delete(new ContentDeleteRequest(99L)))
+			.isInstanceOf(LxpException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_CONTENT.getMessage());
+		verify(contentRepository, never()).deleteById(any());
+	}
+}

--- a/src/test/java/com/lxp/view/ContentDetailViewTest.java
+++ b/src/test/java/com/lxp/view/ContentDetailViewTest.java
@@ -1,0 +1,83 @@
+package com.lxp.view;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.ContentController;
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.controller.response.ContentDeleteResponse;
+import com.lxp.controller.response.ContentDetailResponse;
+import com.lxp.controller.response.ContentUpdateResponse;
+import com.lxp.view.command.ContentDetailCommand;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContentDetailView 테스트")
+class ContentDetailViewTest {
+
+	@Mock
+	private MenuRenderer menuRenderer;
+
+	@Mock
+	private InputView inputView;
+
+	@Mock
+	private OutputView outputView;
+
+	@Mock
+	private ContentController contentController;
+
+	@InjectMocks
+	private ContentDetailView contentDetailView;
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 상세 화면 본문을 출력한다")
+	void screen() {
+		contentDetailView.run(1L);
+		when(contentController.findDetailById(1L))
+			.thenReturn(new ContentDetailResponse(1L, "원시타입", "설명", "TEXT"));
+
+		MenuScreen screen = contentDetailView.screen();
+
+		assertThat(screen.title()).isEqualTo("콘텐츠 상세");
+		assertThat(screen.body()).contains("콘텐츠 제목  : 원시타입", "콘텐츠 타입  : TEXT", "콘텐츠 내용  : 설명");
+	}
+
+	@Test
+	@DisplayName("성공 - UPDATE 처리 시 입력을 받아 수정 후 성공 문구를 출력한다")
+	void handle_update() {
+		contentDetailView.run(1L);
+		when(inputView.readLine()).thenReturn("Stream", "Stream 설명");
+		when(contentController.update(new ContentUpdateRequest(1L, "Stream", "Stream 설명")))
+			.thenReturn(new ContentUpdateResponse(1L));
+
+		boolean result = contentDetailView.handle(ContentDetailCommand.UPDATE);
+
+		verify(outputView).printHeader("콘텐츠 수정");
+		verify(outputView).printLabel("  수정할 제목  : ");
+		verify(outputView).printLabel("  수정할 내용  : ");
+		verify(contentController).update(new ContentUpdateRequest(1L, "Stream", "Stream 설명"));
+		verify(outputView).printSuccess("  수정되었습니다. id: 1");
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("성공 - DELETE 처리 시 삭제 후 화면을 종료한다")
+	void handle_delete() {
+		contentDetailView.run(1L);
+		when(contentController.delete(new ContentDeleteRequest(1L))).thenReturn(new ContentDeleteResponse(1L));
+
+		boolean result = contentDetailView.handle(ContentDetailCommand.DELETE);
+
+		verify(contentController).delete(new ContentDeleteRequest(1L));
+		verify(outputView).printSuccess("  삭제가 완료되었습니다. id: 1");
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/com/lxp/view/ContentSelectViewTest.java
+++ b/src/test/java/com/lxp/view/ContentSelectViewTest.java
@@ -1,0 +1,84 @@
+package com.lxp.view;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lxp.controller.ContentController;
+import com.lxp.controller.response.ContentListResponse;
+import com.lxp.controller.response.ContentSummaryResponse;
+import com.lxp.view.command.ContentSelectCommand;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContentSelectView 테스트")
+class ContentSelectViewTest {
+
+	@Mock
+	private MenuRenderer menuRenderer;
+
+	@Mock
+	private OutputView outputView;
+
+	@Mock
+	private ContentController contentController;
+
+	@Mock
+	private ContentDetailView contentDetailView;
+
+	@InjectMocks
+	private ContentSelectView contentSelectView;
+
+	@Test
+	@DisplayName("성공 - 콘텐츠 목록 본문을 출력한다")
+	void screen_withContents() {
+		contentSelectView.run(1L);
+		when(contentController.findAllByCourseId(1L)).thenReturn(new ContentListResponse(List.of(
+			new ContentSummaryResponse(1L, "원시타입"),
+			new ContentSummaryResponse(2L, "for 문")
+		)));
+		when(outputView.muted("  선택할 콘텐츠 id를 입력하세요. (0: 뒤로 가기)")).thenReturn("guide");
+
+		MenuScreen screen = contentSelectView.screen();
+
+		assertThat(screen.body()).contains("1. 원시타입", "id: 1", "2. for 문", "guide");
+	}
+
+	@Test
+	@DisplayName("성공 - 등록된 콘텐츠가 없으면 빈 상태 문구를 출력한다")
+	void screen_empty() {
+		contentSelectView.run(1L);
+		when(contentController.findAllByCourseId(1L)).thenReturn(new ContentListResponse(List.of()));
+		when(outputView.muted("  등록된 콘텐츠가 없습니다.")).thenReturn("empty");
+		when(outputView.muted("  선택할 콘텐츠 id를 입력하세요. (0: 뒤로 가기)")).thenReturn("guide");
+
+		MenuScreen screen = contentSelectView.screen();
+
+		assertThat(screen.body()).isEqualTo("empty\nguide");
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 선택하면 상세 화면으로 이동한다")
+	void handle_select() {
+		boolean result = contentSelectView.handle(ContentSelectCommand.from(2));
+
+		verify(contentDetailView).run(2L);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("성공 - 0 입력 시 이전 화면으로 돌아간다")
+	void handle_back() {
+		boolean result = contentSelectView.handle(ContentSelectCommand.from(0));
+
+		verifyNoInteractions(contentDetailView);
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/com/lxp/view/CourseDetailViewTest.java
+++ b/src/test/java/com/lxp/view/CourseDetailViewTest.java
@@ -13,9 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.lxp.controller.ContentController;
 import com.lxp.controller.CourseController;
+import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseUpdateRequest;
+import com.lxp.controller.response.ContentRegisterResponse;
 import com.lxp.controller.response.ContentSummaryResponse;
 import com.lxp.controller.response.CourseDeleteResponse;
 import com.lxp.controller.response.CourseDetailResponse;
@@ -37,6 +40,12 @@ class CourseDetailViewTest {
 
 	@Mock
 	private CourseController courseController;
+
+	@Mock
+	private ContentController contentController;
+
+	@Mock
+	private ContentSelectView contentSelectView;
 
 	@InjectMocks
 	private CourseDetailView courseDetailView;
@@ -111,11 +120,32 @@ class CourseDetailViewTest {
 	}
 
 	@Test
-	@DisplayName("성공 - 콘텐츠 선택은 아직 구현 예정 안내 문구를 출력한다")
+	@DisplayName("성공 - REGISTER_CONTENT 처리 시 입력을 받아 콘텐츠 등록 후 성공 문구를 출력한다")
+	void handle_registerContent() {
+		courseDetailView.run(1L);
+		when(inputView.readLine()).thenReturn("Stream", "TEXT", "Stream API 설명");
+		when(contentController.register(new ContentRegisterRequest(1L, "Stream", "Stream API 설명", "TEXT")))
+			.thenReturn(new ContentRegisterResponse(3L));
+
+		boolean result = courseDetailView.handle(CourseDetailCommand.REGISTER_CONTENT);
+
+		verify(outputView).printHeader("콘텐츠 등록");
+		verify(outputView).printLabel("  콘텐츠 제목  : ");
+		verify(outputView).printLabel("  콘텐츠 타입(VIDEO/TEXT/FILE)  : ");
+		verify(outputView).printLabel("  콘텐츠 내용  : ");
+		verify(contentController).register(new ContentRegisterRequest(1L, "Stream", "Stream API 설명", "TEXT"));
+		verify(outputView).printSuccess("  콘텐츠가 등록되었습니다. id: 3");
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("성공 - SELECT_CONTENT 처리 시 콘텐츠 선택 화면으로 이동한다")
 	void handle_selectContent() {
+		courseDetailView.run(1L);
+
 		boolean result = courseDetailView.handle(CourseDetailCommand.SELECT_CONTENT);
 
-		verify(outputView).printNotImplemented();
+		verify(contentSelectView).run(1L);
 		assertThat(result).isTrue();
 	}
 


### PR DESCRIPTION
## Summary
- 콘텐츠 등록, 목록, 상세, 수정, 삭제 흐름 추가
- 콘텐츠 관리 controller/service/view 및 수동 DI 연결
- 콘텐츠 타입 입력 변환과 관련 테스트 보강

## Test
- ./gradlew test

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 강좌 내 콘텐츠 등록, 조회, 수정, 삭제 기능 추가
- 콘텐츠 목록에서 특정 콘텐츠 선택 및 상세 정보 확인 가능
- 콘텐츠 유형(비디오, 텍스트, 파일) 관리 지원

## 테스트
- 콘텐츠 관리 기능에 대한 포괄적인 단위 테스트 추가
- 요청/응답 데이터 유효성 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->