### PR TITLE
[feat] JDBC 저장소 기반 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+config.yml

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'mysql:mysql-connector-java:8.0.33'
+
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
 

--- a/src/main/java/com/lxp/config/AppConfig.java
+++ b/src/main/java/com/lxp/config/AppConfig.java
@@ -15,7 +15,9 @@ public class AppConfig {
 	private final ViewConfig viewConfig = new ViewConfig(controllerConfig);
 
 	public AppConfig() {
-		mockDataInitializer.initialize();
+		if (!repositoryConfig.isJdbcMode()) {
+			mockDataInitializer.initialize();
+		}
 	}
 
 	public MainView mainView() {

--- a/src/main/java/com/lxp/config/AppProperties.java
+++ b/src/main/java/com/lxp/config/AppProperties.java
@@ -1,0 +1,14 @@
+package com.lxp.config;
+
+public record AppProperties(
+	String repositoryMode,
+	DatabaseProperties db
+) {
+
+	public record DatabaseProperties(
+		String url,
+		String username,
+		String password
+	) {
+	}
+}

--- a/src/main/java/com/lxp/config/ConfigLoader.java
+++ b/src/main/java/com/lxp/config/ConfigLoader.java
@@ -1,0 +1,96 @@
+package com.lxp.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+public class ConfigLoader {
+
+	private static final String CONFIG_FILE = "config.yml";
+	private static final String DEFAULT_REPOSITORY_MODE = "inmemory";
+	private static final String DEFAULT_URL = "";
+	private static final String DEFAULT_USERNAME = "";
+	private static final String DEFAULT_PASSWORD = "";
+
+	public AppProperties load() {
+		try (InputStream inputStream = resourceStream()) {
+			Map<String, String> values = parse(inputStream);
+			return new AppProperties(
+				values.getOrDefault("repository.mode", DEFAULT_REPOSITORY_MODE),
+				new AppProperties.DatabaseProperties(
+					values.getOrDefault("db.url", DEFAULT_URL),
+					values.getOrDefault("db.username", DEFAULT_USERNAME),
+					values.getOrDefault("db.password", DEFAULT_PASSWORD)
+				)
+			);
+		} catch (IOException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private InputStream resourceStream() {
+		InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+		if (inputStream == null) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+		return inputStream;
+	}
+
+	private Map<String, String> parse(InputStream inputStream) throws IOException {
+		Map<String, String> values = new LinkedHashMap<>();
+		try (BufferedReader reader = new BufferedReader(
+			new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+			String currentSection = "";
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (line.isBlank() || line.stripLeading().startsWith("#")) {
+					continue;
+				}
+
+				int indent = indentation(line);
+				String trimmed = line.trim();
+				if (trimmed.endsWith(":")) {
+					currentSection = trimmed.substring(0, trimmed.length() - 1);
+					continue;
+				}
+
+				String[] keyValue = trimmed.split(":", 2);
+				if (keyValue.length != 2) {
+					continue;
+				}
+
+				String key = keyValue[0].trim();
+				String value = stripQuotes(keyValue[1].trim());
+				String fullKey = indent > 0 && !currentSection.isBlank() ? currentSection + "." + key : key;
+				values.put(fullKey, value);
+			}
+		}
+		return values;
+	}
+
+	private int indentation(String line) {
+		int indent = 0;
+		while (indent < line.length() && line.charAt(indent) == ' ') {
+			indent++;
+		}
+		return indent;
+	}
+
+	private String stripQuotes(String value) {
+		if (value.length() >= 2) {
+			boolean doubleQuoted = value.startsWith("\"") && value.endsWith("\"");
+			boolean singleQuoted = value.startsWith("'") && value.endsWith("'");
+			if (doubleQuoted || singleQuoted) {
+				return value.substring(1, value.length() - 1);
+			}
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/lxp/config/RepositoryConfig.java
+++ b/src/main/java/com/lxp/config/RepositoryConfig.java
@@ -6,12 +6,36 @@ import com.lxp.repository.InstructorRepository;
 import com.lxp.repository.inmemory.InMemoryContentRepository;
 import com.lxp.repository.inmemory.InMemoryCourseRepository;
 import com.lxp.repository.inmemory.InMemoryInstructorRepository;
+import com.lxp.repository.jdbc.DriverManagerConnectionProvider;
+import com.lxp.repository.jdbc.JdbcContentRepository;
+import com.lxp.repository.jdbc.JdbcCourseRepository;
+import com.lxp.repository.jdbc.JdbcInstructorRepository;
+import com.lxp.repository.jdbc.JdbcTemplate;
 
 public class RepositoryConfig {
 
-	private final CourseRepository courseRepository = new InMemoryCourseRepository();
-	private final ContentRepository contentRepository = new InMemoryContentRepository();
-	private final InstructorRepository instructorRepository = new InMemoryInstructorRepository();
+	private static final String JDBC = "jdbc";
+
+	private final CourseRepository courseRepository;
+	private final ContentRepository contentRepository;
+	private final InstructorRepository instructorRepository;
+	private final boolean jdbcMode;
+
+	public RepositoryConfig() {
+		AppProperties appProperties = new ConfigLoader().load();
+		this.jdbcMode = JDBC.equalsIgnoreCase(appProperties.repositoryMode());
+		if (jdbcMode) {
+			JdbcTemplate jdbcTemplate = new JdbcTemplate(DriverManagerConnectionProvider.from(appProperties.db()));
+			this.courseRepository = new JdbcCourseRepository(jdbcTemplate);
+			this.contentRepository = new JdbcContentRepository(jdbcTemplate);
+			this.instructorRepository = new JdbcInstructorRepository(jdbcTemplate);
+			return;
+		}
+
+		this.courseRepository = new InMemoryCourseRepository();
+		this.contentRepository = new InMemoryContentRepository();
+		this.instructorRepository = new InMemoryInstructorRepository();
+	}
 
 	public CourseRepository courseRepository() {
 		return courseRepository;
@@ -23,5 +47,9 @@ public class RepositoryConfig {
 
 	public InstructorRepository instructorRepository() {
 		return instructorRepository;
+	}
+
+	public boolean isJdbcMode() {
+		return jdbcMode;
 	}
 }

--- a/src/main/java/com/lxp/repository/jdbc/ConnectionProvider.java
+++ b/src/main/java/com/lxp/repository/jdbc/ConnectionProvider.java
@@ -1,0 +1,10 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ConnectionProvider {
+
+	Connection getConnection() throws SQLException;
+}

--- a/src/main/java/com/lxp/repository/jdbc/DriverManagerConnectionProvider.java
+++ b/src/main/java/com/lxp/repository/jdbc/DriverManagerConnectionProvider.java
@@ -1,0 +1,33 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import com.lxp.config.AppProperties;
+
+public class DriverManagerConnectionProvider implements ConnectionProvider {
+
+	private final String url;
+	private final String username;
+	private final String password;
+
+	public DriverManagerConnectionProvider(String url, String username, String password) {
+		this.url = url;
+		this.username = username;
+		this.password = password;
+	}
+
+	public static DriverManagerConnectionProvider from(AppProperties.DatabaseProperties properties) {
+		return new DriverManagerConnectionProvider(
+			properties.url(),
+			properties.username(),
+			properties.password()
+		);
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(url, username, password);
+	}
+}

--- a/src/main/java/com/lxp/repository/jdbc/JdbcContentRepository.java
+++ b/src/main/java/com/lxp/repository/jdbc/JdbcContentRepository.java
@@ -1,0 +1,143 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import com.lxp.domain.Content;
+import com.lxp.domain.enums.ContentType;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.entity.ContentEntity;
+import com.lxp.repository.entity.enums.EntityStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JdbcContentRepository implements ContentRepository {
+
+	private static final String ACTIVE = EntityStatus.ACTIVE.name();
+	private static final String DELETED = EntityStatus.DELETED.name();
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public Optional<Content> findById(Long id) {
+		String sql = """
+			SELECT id, course_id, title, body, content_type, seq, status, created_at, modified_at
+			FROM contents
+			WHERE id = ? AND status = ?
+			""";
+		return jdbcTemplate.queryForObject(
+			sql,
+			preparedStatement -> {
+				preparedStatement.setLong(1, id);
+				preparedStatement.setString(2, ACTIVE);
+			},
+			this::mapRow
+		);
+	}
+
+	@Override
+	public List<Content> findAll() {
+		String sql = """
+			SELECT id, course_id, title, body, content_type, seq, status, created_at, modified_at
+			FROM contents
+			WHERE status = ?
+			ORDER BY course_id, seq, id
+			""";
+		return jdbcTemplate.query(
+			sql,
+			preparedStatement -> preparedStatement.setString(1, ACTIVE),
+			this::mapRow
+		);
+	}
+
+	@Override
+	public Content save(Content content) {
+		if (content.getId() == null) {
+			return saveNew(content);
+		}
+		return saveExisting(content);
+	}
+
+	@Override
+	public void deleteById(Long id) {
+		String sql = """
+			UPDATE contents
+			SET status = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setString(1, DELETED);
+			preparedStatement.setTimestamp(2, Timestamp.valueOf(LocalDateTime.now()));
+			preparedStatement.setLong(3, id);
+			preparedStatement.setString(4, ACTIVE);
+		});
+	}
+
+	private Content saveNew(Content content) {
+		LocalDateTime now = LocalDateTime.now();
+		String sql = """
+			INSERT INTO contents (course_id, title, body, content_type, seq, status, created_at, modified_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			""";
+		long id = jdbcTemplate.insert(sql, preparedStatement -> {
+			preparedStatement.setLong(1, content.getCourseId());
+			preparedStatement.setString(2, content.getTitle());
+			preparedStatement.setString(3, content.getBody());
+			preparedStatement.setString(4, content.getContentType().name());
+			preparedStatement.setInt(5, content.getSeq());
+			preparedStatement.setString(6, ACTIVE);
+			preparedStatement.setTimestamp(7, Timestamp.valueOf(now));
+			preparedStatement.setTimestamp(8, Timestamp.valueOf(now));
+		});
+		return Content.createWithId(
+			id,
+			content.getCourseId(),
+			content.getTitle(),
+			content.getBody(),
+			content.getContentType(),
+			content.getSeq()
+		);
+	}
+
+	private Content saveExisting(Content content) {
+		String sql = """
+			UPDATE contents
+			SET title = ?, body = ?, content_type = ?, seq = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		int updated = jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setString(1, content.getTitle());
+			preparedStatement.setString(2, content.getBody());
+			preparedStatement.setString(3, content.getContentType().name());
+			preparedStatement.setInt(4, content.getSeq());
+			preparedStatement.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()));
+			preparedStatement.setLong(6, content.getId());
+			preparedStatement.setString(7, ACTIVE);
+		});
+		if (updated == 0) {
+			throw new LxpException(ErrorCode.NOT_FOUND_CONTENT);
+		}
+		return content;
+	}
+
+	private Content mapRow(ResultSet resultSet) throws SQLException {
+		return ContentEntity.restore(
+			resultSet.getLong("id"),
+			resultSet.getLong("course_id"),
+			resultSet.getString("title"),
+			resultSet.getString("body"),
+			ContentType.valueOf(resultSet.getString("content_type")),
+			resultSet.getInt("seq"),
+			EntityStatus.valueOf(resultSet.getString("status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime(),
+			resultSet.getTimestamp("modified_at").toLocalDateTime()
+		).toDomain();
+	}
+}

--- a/src/main/java/com/lxp/repository/jdbc/JdbcCourseRepository.java
+++ b/src/main/java/com/lxp/repository/jdbc/JdbcCourseRepository.java
@@ -1,0 +1,156 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import com.lxp.domain.Course;
+import com.lxp.domain.enums.Level;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.CourseRepository;
+import com.lxp.repository.entity.CourseEntity;
+import com.lxp.repository.entity.enums.EntityStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JdbcCourseRepository implements CourseRepository {
+
+	private static final String ACTIVE = EntityStatus.ACTIVE.name();
+	private static final String DELETED = EntityStatus.DELETED.name();
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public Optional<Course> findById(Long id) {
+		String sql = """
+			SELECT id, instructor_id, title, description, price, level, status, created_at, modified_at
+			FROM courses
+			WHERE id = ? AND status = ?
+			""";
+		return jdbcTemplate.queryForObject(
+			sql,
+			preparedStatement -> {
+				preparedStatement.setLong(1, id);
+				preparedStatement.setString(2, ACTIVE);
+			},
+			this::mapRow
+		);
+	}
+
+	@Override
+	public List<Course> findAll() {
+		String sql = """
+			SELECT id, instructor_id, title, description, price, level, status, created_at, modified_at
+			FROM courses
+			WHERE status = ?
+			ORDER BY id
+			""";
+		return jdbcTemplate.query(
+			sql,
+			preparedStatement -> preparedStatement.setString(1, ACTIVE),
+			this::mapRow
+		);
+	}
+
+	@Override
+	public Course save(Course course) {
+		if (course.getId() == null) {
+			return saveNew(course);
+		}
+		return saveExisting(course);
+	}
+
+	@Override
+	public void deleteById(Long id) {
+		String sql = """
+			UPDATE courses
+			SET status = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setString(1, DELETED);
+			preparedStatement.setTimestamp(2, Timestamp.valueOf(LocalDateTime.now()));
+			preparedStatement.setLong(3, id);
+			preparedStatement.setString(4, ACTIVE);
+		});
+	}
+
+	private Course saveNew(Course course) {
+		LocalDateTime now = LocalDateTime.now();
+		String sql = """
+			INSERT INTO courses (instructor_id, title, description, price, level, status, created_at, modified_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			""";
+		long id = jdbcTemplate.insert(sql, preparedStatement -> {
+			preparedStatement.setLong(1, course.getInstructorId());
+			preparedStatement.setString(2, course.getTitle());
+			preparedStatement.setString(3, course.getDescription());
+			preparedStatement.setInt(4, course.getPrice());
+			preparedStatement.setString(5, course.getLevel().name());
+			preparedStatement.setString(6, ACTIVE);
+			preparedStatement.setTimestamp(7, Timestamp.valueOf(now));
+			preparedStatement.setTimestamp(8, Timestamp.valueOf(now));
+		});
+		return Course.createWithId(
+			id,
+			course.getInstructorId(),
+			course.getTitle(),
+			course.getDescription(),
+			course.getPrice(),
+			course.getLevel(),
+			now,
+			now
+		);
+	}
+
+	private Course saveExisting(Course course) {
+		LocalDateTime now = LocalDateTime.now();
+		String sql = """
+			UPDATE courses
+			SET instructor_id = ?, title = ?, description = ?, price = ?, level = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		int updated = jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setLong(1, course.getInstructorId());
+			preparedStatement.setString(2, course.getTitle());
+			preparedStatement.setString(3, course.getDescription());
+			preparedStatement.setInt(4, course.getPrice());
+			preparedStatement.setString(5, course.getLevel().name());
+			preparedStatement.setTimestamp(6, Timestamp.valueOf(now));
+			preparedStatement.setLong(7, course.getId());
+			preparedStatement.setString(8, ACTIVE);
+		});
+		if (updated == 0) {
+			throw new LxpException(ErrorCode.NOT_FOUND_COURSE);
+		}
+		return Course.createWithId(
+			course.getId(),
+			course.getInstructorId(),
+			course.getTitle(),
+			course.getDescription(),
+			course.getPrice(),
+			course.getLevel(),
+			course.getCreatedAt(),
+			now
+		);
+	}
+
+	private Course mapRow(ResultSet resultSet) throws SQLException {
+		return CourseEntity.restore(
+			resultSet.getLong("id"),
+			resultSet.getLong("instructor_id"),
+			resultSet.getString("title"),
+			resultSet.getString("description"),
+			resultSet.getInt("price"),
+			Level.valueOf(resultSet.getString("level")),
+			EntityStatus.valueOf(resultSet.getString("status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime(),
+			resultSet.getTimestamp("modified_at").toLocalDateTime()
+		).toDomain();
+	}
+}

--- a/src/main/java/com/lxp/repository/jdbc/JdbcInstructorRepository.java
+++ b/src/main/java/com/lxp/repository/jdbc/JdbcInstructorRepository.java
@@ -1,0 +1,128 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import com.lxp.domain.Instructor;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.InstructorRepository;
+import com.lxp.repository.entity.InstructorEntity;
+import com.lxp.repository.entity.enums.EntityStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JdbcInstructorRepository implements InstructorRepository {
+
+	private static final String ACTIVE = EntityStatus.ACTIVE.name();
+	private static final String DELETED = EntityStatus.DELETED.name();
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public Optional<Instructor> findById(Long id) {
+		String sql = """
+			SELECT id, name, introduction, status, created_at, modified_at
+			FROM instructors
+			WHERE id = ? AND status = ?
+			""";
+		return jdbcTemplate.queryForObject(
+			sql,
+			preparedStatement -> {
+				preparedStatement.setLong(1, id);
+				preparedStatement.setString(2, ACTIVE);
+			},
+			this::mapRow
+		);
+	}
+
+	@Override
+	public List<Instructor> findAll() {
+		String sql = """
+			SELECT id, name, introduction, status, created_at, modified_at
+			FROM instructors
+			WHERE status = ?
+			ORDER BY id
+			""";
+		return jdbcTemplate.query(
+			sql,
+			preparedStatement -> preparedStatement.setString(1, ACTIVE),
+			this::mapRow
+		);
+	}
+
+	@Override
+	public Instructor save(Instructor instructor) {
+		if (instructor.getId() == null) {
+			return saveNew(instructor);
+		}
+		return saveExisting(instructor);
+	}
+
+	@Override
+	public void deleteById(Long id) {
+		String sql = """
+			UPDATE instructors
+			SET status = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setString(1, DELETED);
+			preparedStatement.setTimestamp(2, Timestamp.valueOf(LocalDateTime.now()));
+			preparedStatement.setLong(3, id);
+			preparedStatement.setString(4, ACTIVE);
+		});
+	}
+
+	private Instructor saveNew(Instructor instructor) {
+		LocalDateTime now = LocalDateTime.now();
+		String sql = """
+			INSERT INTO instructors (name, introduction, status, created_at, modified_at)
+			VALUES (?, ?, ?, ?, ?)
+			""";
+		long id = jdbcTemplate.insert(sql, preparedStatement -> {
+			preparedStatement.setString(1, instructor.getName());
+			preparedStatement.setString(2, instructor.getIntroduction());
+			preparedStatement.setString(3, ACTIVE);
+			preparedStatement.setTimestamp(4, Timestamp.valueOf(now));
+			preparedStatement.setTimestamp(5, Timestamp.valueOf(now));
+		});
+		return Instructor.createWithId(id, instructor.getName(), instructor.getIntroduction());
+	}
+
+	private Instructor saveExisting(Instructor instructor) {
+		LocalDateTime now = LocalDateTime.now();
+		String sql = """
+			UPDATE instructors
+			SET name = ?, introduction = ?, modified_at = ?
+			WHERE id = ? AND status = ?
+			""";
+		int updated = jdbcTemplate.update(sql, preparedStatement -> {
+			preparedStatement.setString(1, instructor.getName());
+			preparedStatement.setString(2, instructor.getIntroduction());
+			preparedStatement.setTimestamp(3, Timestamp.valueOf(now));
+			preparedStatement.setLong(4, instructor.getId());
+			preparedStatement.setString(5, ACTIVE);
+		});
+		if (updated == 0) {
+			throw new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR);
+		}
+		return instructor;
+	}
+
+	private Instructor mapRow(ResultSet resultSet) throws SQLException {
+		return InstructorEntity.restore(
+			resultSet.getLong("id"),
+			resultSet.getString("name"),
+			resultSet.getString("introduction"),
+			EntityStatus.valueOf(resultSet.getString("status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime(),
+			resultSet.getTimestamp("modified_at").toLocalDateTime()
+		).toDomain();
+	}
+}

--- a/src/main/java/com/lxp/repository/jdbc/JdbcTemplate.java
+++ b/src/main/java/com/lxp/repository/jdbc/JdbcTemplate.java
@@ -1,0 +1,85 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JdbcTemplate {
+
+	private final ConnectionProvider connectionProvider;
+
+	public int update(String sql, PreparedStatementSetter statementSetter) {
+		try (
+			Connection connection = connectionProvider.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(sql)
+		) {
+			statementSetter.setValues(preparedStatement);
+			return preparedStatement.executeUpdate();
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public long insert(String sql, PreparedStatementSetter statementSetter) {
+		try (
+			Connection connection = connectionProvider.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
+		) {
+			statementSetter.setValues(preparedStatement);
+			preparedStatement.executeUpdate();
+			return generatedKey(preparedStatement);
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public <T> List<T> query(String sql, PreparedStatementSetter statementSetter, RowMapper<T> rowMapper) {
+		try (
+			Connection connection = connectionProvider.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(sql)
+		) {
+			statementSetter.setValues(preparedStatement);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				List<T> rows = new ArrayList<>();
+				while (resultSet.next()) {
+					rows.add(rowMapper.map(resultSet));
+				}
+				return rows;
+			}
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public <T> Optional<T> queryForObject(
+		String sql,
+		PreparedStatementSetter statementSetter,
+		RowMapper<T> rowMapper
+	) {
+		List<T> rows = query(sql, statementSetter, rowMapper);
+		if (rows.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(rows.get(0));
+	}
+
+	private long generatedKey(PreparedStatement preparedStatement) throws SQLException {
+		try (ResultSet generatedKeys = preparedStatement.getGeneratedKeys()) {
+			if (generatedKeys.next()) {
+				return generatedKeys.getLong(1);
+			}
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/lxp/repository/jdbc/PreparedStatementSetter.java
+++ b/src/main/java/com/lxp/repository/jdbc/PreparedStatementSetter.java
@@ -1,0 +1,10 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementSetter {
+
+	void setValues(PreparedStatement preparedStatement) throws SQLException;
+}

--- a/src/main/java/com/lxp/repository/jdbc/RowMapper.java
+++ b/src/main/java/com/lxp/repository/jdbc/RowMapper.java
@@ -1,0 +1,10 @@
+package com.lxp.repository.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface RowMapper<T> {
+
+	T map(ResultSet resultSet) throws SQLException;
+}

--- a/src/main/resources/config-example.yml
+++ b/src/main/resources/config-example.yml
@@ -1,0 +1,7 @@
+repository:
+  mode: jdbc
+
+db:
+  url: "jdbc:mysql://localhost:3306/lxp"
+  username: "username"
+  password: ""

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -1,0 +1,51 @@
+CREATE TABLE instructors
+(
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    name         VARCHAR(10)  NOT NULL,
+    introduction VARCHAR(100) NOT NULL,
+    status       VARCHAR(20)  NOT NULL,
+    created_at   DATETIME(6)  NOT NULL,
+    modified_at  DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT chk_instructors_status CHECK (status IN ('ACTIVE', 'DELETED'))
+);
+
+CREATE TABLE courses
+(
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    instructor_id BIGINT       NOT NULL,
+    title         VARCHAR(50)  NOT NULL,
+    description   VARCHAR(200) NOT NULL,
+    price         INT          NOT NULL,
+    level         VARCHAR(20)  NOT NULL,
+    status        VARCHAR(20)  NOT NULL,
+    created_at    DATETIME(6)  NOT NULL,
+    modified_at   DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_courses_instructor FOREIGN KEY (instructor_id) REFERENCES instructors (id),
+    CONSTRAINT chk_courses_price CHECK (price >= 0),
+    CONSTRAINT chk_courses_level CHECK (level IN ('LOW', 'MIDDLE', 'HIGH')),
+    CONSTRAINT chk_courses_status CHECK (status IN ('ACTIVE', 'DELETED'))
+);
+
+CREATE TABLE contents
+(
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    course_id    BIGINT       NOT NULL,
+    title        VARCHAR(50)  NOT NULL,
+    body         VARCHAR(200) NOT NULL,
+    content_type VARCHAR(20)  NOT NULL,
+    seq          INT          NOT NULL,
+    status       VARCHAR(20)  NOT NULL,
+    created_at   DATETIME(6)  NOT NULL,
+    modified_at  DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_contents_course FOREIGN KEY (course_id) REFERENCES courses (id),
+    CONSTRAINT chk_contents_content_type CHECK (content_type IN ('VIDEO', 'TEXT', 'FILE')),
+    CONSTRAINT chk_contents_seq CHECK (seq > 0),
+    CONSTRAINT chk_contents_status CHECK (status IN ('ACTIVE', 'DELETED'))
+);
+
+CREATE INDEX idx_courses_status ON courses (status);
+CREATE INDEX idx_contents_course_id_status_seq ON contents (course_id, status, seq);
+CREATE INDEX idx_instructors_status ON instructors (status);


### PR DESCRIPTION
## 🔗 관련 이슈
- 없음

## 📌 개요
- Phase 2 전환을 위한 JDBC/MySQL 저장소 기반을 추가합니다.

## ✨ 변경 사항
- MySQL 스키마 생성을 위한 `ddl.sql` 추가
- `DriverManager` 기반 `ConnectionProvider`와 `JdbcTemplate` 전략 패턴 추가
- `JdbcCourseRepository`, `JdbcContentRepository`, `JdbcInstructorRepository` 추가
- repository 모드에 따라 JDBC 저장소를 사용할 수 있도록 설정 연결
- DB 설정 예시 파일과 `config.yml` ignore 규칙 추가

## 🔥 변경 이유(선택)
- repository에서 반복되는 `Connection`/`PreparedStatement` 생성 코드를 공통화하고, MySQL 전환 기반을 먼저 마련하기 위해

## 🧪 테스트
- [x] 로컬 테스트 완료
- `./gradlew test`

## 🤔 고민한 부분 (선택)
- 실제 앱 실행 환경에서는 `config.yml`을 로컬에서 따로 두고, 저장소에는 `config-example.yml`만 남기도록 분리했습니다.

## 📸 스크린샷 (선택)
- 없음

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * MySQL 데이터베이스 백엔드 지원 추가 (인메모리 모드와 함께 사용 가능)
  * YAML 설정 파일을 통한 데이터베이스 연결 설정 지원
  * 데이터 일관성을 위한 트랜잭션 관리 기능 추가

* **기타 변경사항**
  * MySQL 데이터베이스 연결 드라이버 추가
  * 강사, 강의, 콘텐츠 관리를 위한 데이터베이스 스키마 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->