### PR TITLE
[feat] 서비스 트랜잭션 프록시 적용

### DIFF
--- a/src/main/java/com/lxp/config/ConfigLoader.java
+++ b/src/main/java/com/lxp/config/ConfigLoader.java
@@ -20,7 +20,11 @@ public class ConfigLoader {
 	private static final String DEFAULT_PASSWORD = "";
 
 	public AppProperties load() {
-		try (InputStream inputStream = resourceStream()) {
+		return load(CONFIG_FILE);
+	}
+
+	public AppProperties load(String resourceName) {
+		try (InputStream inputStream = resourceStream(resourceName)) {
 			Map<String, String> values = parse(inputStream);
 			return new AppProperties(
 				values.getOrDefault("repository.mode", DEFAULT_REPOSITORY_MODE),
@@ -36,7 +40,11 @@ public class ConfigLoader {
 	}
 
 	private InputStream resourceStream() {
-		InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+		return resourceStream(CONFIG_FILE);
+	}
+
+	private InputStream resourceStream(String resourceName) {
+		InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourceName);
 		if (inputStream == null) {
 			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}

--- a/src/main/java/com/lxp/config/RepositoryConfig.java
+++ b/src/main/java/com/lxp/config/RepositoryConfig.java
@@ -6,6 +6,7 @@ import com.lxp.repository.InstructorRepository;
 import com.lxp.repository.inmemory.InMemoryContentRepository;
 import com.lxp.repository.inmemory.InMemoryCourseRepository;
 import com.lxp.repository.inmemory.InMemoryInstructorRepository;
+import com.lxp.repository.jdbc.ConnectionProvider;
 import com.lxp.repository.jdbc.DriverManagerConnectionProvider;
 import com.lxp.repository.jdbc.JdbcContentRepository;
 import com.lxp.repository.jdbc.JdbcCourseRepository;
@@ -19,19 +20,22 @@ public class RepositoryConfig {
 	private final CourseRepository courseRepository;
 	private final ContentRepository contentRepository;
 	private final InstructorRepository instructorRepository;
+	private final ConnectionProvider connectionProvider;
 	private final boolean jdbcMode;
 
 	public RepositoryConfig() {
 		AppProperties appProperties = new ConfigLoader().load();
 		this.jdbcMode = JDBC.equalsIgnoreCase(appProperties.repositoryMode());
 		if (jdbcMode) {
-			JdbcTemplate jdbcTemplate = new JdbcTemplate(DriverManagerConnectionProvider.from(appProperties.db()));
+			this.connectionProvider = DriverManagerConnectionProvider.from(appProperties.db());
+			JdbcTemplate jdbcTemplate = new JdbcTemplate(connectionProvider);
 			this.courseRepository = new JdbcCourseRepository(jdbcTemplate);
 			this.contentRepository = new JdbcContentRepository(jdbcTemplate);
 			this.instructorRepository = new JdbcInstructorRepository(jdbcTemplate);
 			return;
 		}
 
+		this.connectionProvider = null;
 		this.courseRepository = new InMemoryCourseRepository();
 		this.contentRepository = new InMemoryContentRepository();
 		this.instructorRepository = new InMemoryInstructorRepository();
@@ -51,5 +55,9 @@ public class RepositoryConfig {
 
 	public boolean isJdbcMode() {
 		return jdbcMode;
+	}
+
+	public ConnectionProvider connectionProvider() {
+		return connectionProvider;
 	}
 }

--- a/src/main/java/com/lxp/config/ServiceConfig.java
+++ b/src/main/java/com/lxp/config/ServiceConfig.java
@@ -2,7 +2,12 @@ package com.lxp.config;
 
 import com.lxp.service.ContentService;
 import com.lxp.service.CourseService;
+import com.lxp.service.DefaultContentService;
+import com.lxp.service.DefaultCourseService;
+import com.lxp.service.DefaultInstructorService;
 import com.lxp.service.InstructorService;
+import com.lxp.transaction.JdbcTransactionManager;
+import com.lxp.transaction.TransactionProxyFactory;
 
 public class ServiceConfig {
 
@@ -11,16 +16,30 @@ public class ServiceConfig {
 	private final InstructorService instructorService;
 
 	public ServiceConfig(RepositoryConfig repositoryConfig) {
-		this.courseService = new CourseService(
+		CourseService courseService = new DefaultCourseService(
 			repositoryConfig.courseRepository(),
 			repositoryConfig.contentRepository(),
 			repositoryConfig.instructorRepository()
 		);
-		this.contentService = new ContentService(
+		ContentService contentService = new DefaultContentService(
 			repositoryConfig.courseRepository(),
 			repositoryConfig.contentRepository()
 		);
-		this.instructorService = new InstructorService(repositoryConfig.instructorRepository());
+		InstructorService instructorService = new DefaultInstructorService(repositoryConfig.instructorRepository());
+
+		if (repositoryConfig.isJdbcMode()) {
+			TransactionProxyFactory proxyFactory = new TransactionProxyFactory(
+				new JdbcTransactionManager(repositoryConfig.connectionProvider())
+			);
+			this.courseService = proxyFactory.createProxy(CourseService.class, courseService);
+			this.contentService = proxyFactory.createProxy(ContentService.class, contentService);
+			this.instructorService = proxyFactory.createProxy(InstructorService.class, instructorService);
+			return;
+		}
+
+		this.courseService = courseService;
+		this.contentService = contentService;
+		this.instructorService = instructorService;
 	}
 
 	public CourseService courseService() {

--- a/src/main/java/com/lxp/repository/jdbc/JdbcTemplate.java
+++ b/src/main/java/com/lxp/repository/jdbc/JdbcTemplate.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import com.lxp.exception.ErrorCode;
 import com.lxp.exception.LxpException;
+import com.lxp.transaction.TransactionSynchronizationManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,35 +21,33 @@ public class JdbcTemplate {
 	private final ConnectionProvider connectionProvider;
 
 	public int update(String sql, PreparedStatementSetter statementSetter) {
-		try (
-			Connection connection = connectionProvider.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(sql)
-		) {
+		Connection connection = connection();
+		try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 			statementSetter.setValues(preparedStatement);
 			return preparedStatement.executeUpdate();
 		} catch (SQLException e) {
 			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			close(connection);
 		}
 	}
 
 	public long insert(String sql, PreparedStatementSetter statementSetter) {
-		try (
-			Connection connection = connectionProvider.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
-		) {
+		Connection connection = connection();
+		try (PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
 			statementSetter.setValues(preparedStatement);
 			preparedStatement.executeUpdate();
 			return generatedKey(preparedStatement);
 		} catch (SQLException e) {
 			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			close(connection);
 		}
 	}
 
 	public <T> List<T> query(String sql, PreparedStatementSetter statementSetter, RowMapper<T> rowMapper) {
-		try (
-			Connection connection = connectionProvider.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(sql)
-		) {
+		Connection connection = connection();
+		try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 			statementSetter.setValues(preparedStatement);
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				List<T> rows = new ArrayList<>();
@@ -59,6 +58,8 @@ public class JdbcTemplate {
 			}
 		} catch (SQLException e) {
 			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			close(connection);
 		}
 	}
 
@@ -79,6 +80,28 @@ public class JdbcTemplate {
 			if (generatedKeys.next()) {
 				return generatedKeys.getLong(1);
 			}
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private Connection connection() {
+		if (TransactionSynchronizationManager.hasConnection()) {
+			return TransactionSynchronizationManager.getConnection();
+		}
+		try {
+			return connectionProvider.getConnection();
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private void close(Connection connection) {
+		if (TransactionSynchronizationManager.isCurrentConnection(connection)) {
+			return;
+		}
+		try {
+			connection.close();
+		} catch (SQLException e) {
 			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/src/main/java/com/lxp/service/ContentService.java
+++ b/src/main/java/com/lxp/service/ContentService.java
@@ -1,79 +1,21 @@
 package com.lxp.service;
 
-import java.util.Comparator;
 import java.util.List;
 
 import com.lxp.controller.request.ContentDeleteRequest;
 import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.ContentUpdateRequest;
 import com.lxp.domain.Content;
-import com.lxp.exception.ErrorCode;
-import com.lxp.exception.LxpException;
-import com.lxp.repository.ContentRepository;
-import com.lxp.repository.CourseRepository;
 
-import lombok.RequiredArgsConstructor;
+public interface ContentService {
 
-@RequiredArgsConstructor
-public class ContentService {
+	Content register(ContentRegisterRequest request);
 
-	private final CourseRepository courseRepository;
-	private final ContentRepository contentRepository;
+	List<Content> findAllByCourseId(Long courseId);
 
-	public Content register(ContentRegisterRequest request) {
-		validateCourseId(request.courseId());
-		Content content = Content.create(
-			request.courseId(),
-			request.title(),
-			request.body(),
-			request.contentType(),
-			nextSeq(request.courseId())
-		);
-		return contentRepository.save(content);
-	}
+	Content findDetailById(Long id);
 
-	public List<Content> findAllByCourseId(Long courseId) {
-		validateCourseId(courseId);
-		return contentRepository.findAll().stream()
-			.filter(content -> content.getCourseId().equals(courseId))
-			.sorted(Comparator.comparingInt(Content::getSeq))
-			.toList();
-	}
+	Content update(ContentUpdateRequest request);
 
-	public Content findDetailById(Long id) {
-		return getContentOrThrow(id);
-	}
-
-	public Content update(ContentUpdateRequest request) {
-		Content content = getContentOrThrow(request.id());
-		content.update(request.title(), request.body());
-		return contentRepository.save(content);
-	}
-
-	public Content delete(ContentDeleteRequest request) {
-		Content content = getContentOrThrow(request.id());
-		contentRepository.deleteById(request.id());
-		return content;
-	}
-
-	private void validateCourseId(Long courseId) {
-		if (courseId == null || courseId <= 0L) {
-			throw new LxpException(ErrorCode.INVALID_INPUT);
-		}
-		courseRepository.findById(courseId)
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
-	}
-
-	private int nextSeq(Long courseId) {
-		return contentRepository.findAll().stream()
-			.filter(content -> content.getCourseId().equals(courseId))
-			.mapToInt(Content::getSeq)
-			.max()
-			.orElse(0) + 1;
-	}
-
-	private Content getContentOrThrow(Long id) {
-		return contentRepository.findById(id)
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_CONTENT));
-	}
+	Content delete(ContentDeleteRequest request);
 }

--- a/src/main/java/com/lxp/service/CourseService.java
+++ b/src/main/java/com/lxp/service/CourseService.java
@@ -1,101 +1,27 @@
 package com.lxp.service;
 
-import java.util.Comparator;
 import java.util.List;
 
-import com.lxp.controller.request.ContentRegisterRequest;
 import com.lxp.controller.request.CourseDeleteRequest;
 import com.lxp.controller.request.CourseRegisterRequest;
 import com.lxp.controller.request.CourseUpdateRequest;
 import com.lxp.domain.Content;
 import com.lxp.domain.Course;
 import com.lxp.domain.Instructor;
-import com.lxp.exception.ErrorCode;
-import com.lxp.exception.LxpException;
-import com.lxp.repository.ContentRepository;
-import com.lxp.repository.CourseRepository;
-import com.lxp.repository.InstructorRepository;
 
-import lombok.RequiredArgsConstructor;
+public interface CourseService {
 
-@RequiredArgsConstructor
-public class CourseService {
+	Course register(CourseRegisterRequest request);
 
-	private final CourseRepository courseRepository;
-	private final ContentRepository contentRepository;
-	private final InstructorRepository instructorRepository;
+	List<Course> findAll();
 
-	public Course register(CourseRegisterRequest request) {
-		validateContentCount(request);
-		Long instructorId = instructorRepository.findById(request.instructorId())
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR))
-			.getId();
-		Course course = Course.create(
-			instructorId,
-			request.title(),
-			request.description(),
-			request.price(),
-			request.level()
-		);
-		Course savedCourse = courseRepository.save(course);
-		saveContents(savedCourse.getId(), request);
-		return savedCourse;
-	}
+	Course findDetailById(Long id);
 
-	public List<Course> findAll() {
-		return courseRepository.findAll();
-	}
+	Instructor findInstructorById(Long id);
 
-	public Course findDetailById(Long id) {
-		return courseRepository.findById(id)
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
-	}
+	List<Content> findContentsByCourseId(Long courseId);
 
-	public Instructor findInstructorById(Long id) {
-		return instructorRepository.findById(id)
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR));
-	}
+	Course update(CourseUpdateRequest request);
 
-	public List<Content> findContentsByCourseId(Long courseId) {
-		findDetailById(courseId);
-		return contentRepository.findAll().stream()
-			.filter(content -> content.getCourseId().equals(courseId))
-			.sorted(Comparator.comparingInt(Content::getSeq))
-			.toList();
-	}
-
-	public Course update(CourseUpdateRequest request) {
-		Course course = findDetailById(request.id());
-		course.update(request.title(), request.description(), request.price(), request.level());
-		return courseRepository.save(course);
-	}
-
-	public Course delete(CourseDeleteRequest request) {
-		Course course = findDetailById(request.id());
-		findContentsByCourseId(request.id())
-			.forEach(content -> contentRepository.deleteById(content.getId()));
-		courseRepository.deleteById(request.id());
-		return course;
-	}
-
-	private void validateContentCount(CourseRegisterRequest request) {
-		int contentCount = request.contents().size();
-		if (contentCount < 1 || contentCount > 10) {
-			throw new LxpException(ErrorCode.COURSE_CONTENT_COUNT_OUT_OF_RANGE);
-		}
-	}
-
-	private void saveContents(Long courseId, CourseRegisterRequest request) {
-		int seq = 1;
-		for (ContentRegisterRequest contentRequest : request.contents()) {
-			Content content = Content.create(
-				courseId,
-				contentRequest.title(),
-				contentRequest.body(),
-				contentRequest.contentType(),
-				seq++
-			);
-			contentRepository.save(content);
-		}
-	}
+	Course delete(CourseDeleteRequest request);
 }

--- a/src/main/java/com/lxp/service/DefaultContentService.java
+++ b/src/main/java/com/lxp/service/DefaultContentService.java
@@ -1,0 +1,88 @@
+package com.lxp.service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.lxp.controller.request.ContentDeleteRequest;
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.ContentUpdateRequest;
+import com.lxp.domain.Content;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.CourseRepository;
+import com.lxp.transaction.Transaction;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultContentService implements ContentService {
+
+	private final CourseRepository courseRepository;
+	private final ContentRepository contentRepository;
+
+	@Override
+	@Transaction
+	public Content register(ContentRegisterRequest request) {
+		validateCourseId(request.courseId());
+		Content content = Content.create(
+			request.courseId(),
+			request.title(),
+			request.body(),
+			request.contentType(),
+			nextSeq(request.courseId())
+		);
+		return contentRepository.save(content);
+	}
+
+	@Override
+	public List<Content> findAllByCourseId(Long courseId) {
+		validateCourseId(courseId);
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.sorted(Comparator.comparingInt(Content::getSeq))
+			.toList();
+	}
+
+	@Override
+	public Content findDetailById(Long id) {
+		return getContentOrThrow(id);
+	}
+
+	@Override
+	@Transaction
+	public Content update(ContentUpdateRequest request) {
+		Content content = getContentOrThrow(request.id());
+		content.update(request.title(), request.body());
+		return contentRepository.save(content);
+	}
+
+	@Override
+	@Transaction
+	public Content delete(ContentDeleteRequest request) {
+		Content content = getContentOrThrow(request.id());
+		contentRepository.deleteById(request.id());
+		return content;
+	}
+
+	private void validateCourseId(Long courseId) {
+		if (courseId == null || courseId <= 0L) {
+			throw new LxpException(ErrorCode.INVALID_INPUT);
+		}
+		courseRepository.findById(courseId)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
+	}
+
+	private int nextSeq(Long courseId) {
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.mapToInt(Content::getSeq)
+			.max()
+			.orElse(0) + 1;
+	}
+
+	private Content getContentOrThrow(Long id) {
+		return contentRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_CONTENT));
+	}
+}

--- a/src/main/java/com/lxp/service/DefaultCourseService.java
+++ b/src/main/java/com/lxp/service/DefaultCourseService.java
@@ -1,0 +1,112 @@
+package com.lxp.service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.lxp.controller.request.ContentRegisterRequest;
+import com.lxp.controller.request.CourseDeleteRequest;
+import com.lxp.controller.request.CourseRegisterRequest;
+import com.lxp.controller.request.CourseUpdateRequest;
+import com.lxp.domain.Content;
+import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.ContentRepository;
+import com.lxp.repository.CourseRepository;
+import com.lxp.repository.InstructorRepository;
+import com.lxp.transaction.Transaction;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultCourseService implements CourseService {
+
+	private final CourseRepository courseRepository;
+	private final ContentRepository contentRepository;
+	private final InstructorRepository instructorRepository;
+
+	@Override
+	@Transaction
+	public Course register(CourseRegisterRequest request) {
+		validateContentCount(request);
+		Long instructorId = instructorRepository.findById(request.instructorId())
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR))
+			.getId();
+		Course course = Course.create(
+			instructorId,
+			request.title(),
+			request.description(),
+			request.price(),
+			request.level()
+		);
+		Course savedCourse = courseRepository.save(course);
+		saveContents(savedCourse.getId(), request);
+		return savedCourse;
+	}
+
+	@Override
+	public List<Course> findAll() {
+		return courseRepository.findAll();
+	}
+
+	@Override
+	public Course findDetailById(Long id) {
+		return courseRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_COURSE));
+	}
+
+	@Override
+	public Instructor findInstructorById(Long id) {
+		return instructorRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR));
+	}
+
+	@Override
+	public List<Content> findContentsByCourseId(Long courseId) {
+		findDetailById(courseId);
+		return contentRepository.findAll().stream()
+			.filter(content -> content.getCourseId().equals(courseId))
+			.sorted(Comparator.comparingInt(Content::getSeq))
+			.toList();
+	}
+
+	@Override
+	@Transaction
+	public Course update(CourseUpdateRequest request) {
+		Course course = findDetailById(request.id());
+		course.update(request.title(), request.description(), request.price(), request.level());
+		return courseRepository.save(course);
+	}
+
+	@Override
+	@Transaction
+	public Course delete(CourseDeleteRequest request) {
+		Course course = findDetailById(request.id());
+		findContentsByCourseId(request.id())
+			.forEach(content -> contentRepository.deleteById(content.getId()));
+		courseRepository.deleteById(request.id());
+		return course;
+	}
+
+	private void validateContentCount(CourseRegisterRequest request) {
+		int contentCount = request.contents().size();
+		if (contentCount < 1 || contentCount > 10) {
+			throw new LxpException(ErrorCode.COURSE_CONTENT_COUNT_OUT_OF_RANGE);
+		}
+	}
+
+	private void saveContents(Long courseId, CourseRegisterRequest request) {
+		int seq = 1;
+		for (ContentRegisterRequest contentRequest : request.contents()) {
+			Content content = Content.create(
+				courseId,
+				contentRequest.title(),
+				contentRequest.body(),
+				contentRequest.contentType(),
+				seq++
+			);
+			contentRepository.save(content);
+		}
+	}
+}

--- a/src/main/java/com/lxp/service/DefaultInstructorService.java
+++ b/src/main/java/com/lxp/service/DefaultInstructorService.java
@@ -1,0 +1,63 @@
+package com.lxp.service;
+
+import java.util.List;
+
+import com.lxp.controller.request.InstructorDeleteRequest;
+import com.lxp.controller.request.InstructorRegisterRequest;
+import com.lxp.controller.request.InstructorUpdateRequest;
+import com.lxp.domain.Instructor;
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.InstructorRepository;
+import com.lxp.transaction.Transaction;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultInstructorService implements InstructorService {
+
+	private final InstructorRepository instructorRepository;
+
+	@Override
+	@Transaction
+	public Instructor register(InstructorRegisterRequest request) {
+		Instructor instructor = Instructor.create(request.name(), request.introduction());
+		return instructorRepository.save(instructor);
+	}
+
+	@Override
+	public List<Instructor> findAll() {
+		return instructorRepository.findAll();
+	}
+
+	@Override
+	public Instructor findById(Long id) {
+		return getInstructorOrThrow(id);
+	}
+
+	@Override
+	public Instructor findDetailById(Long id) {
+		return getInstructorOrThrow(id);
+	}
+
+	@Override
+	@Transaction
+	public Instructor update(InstructorUpdateRequest request) {
+		Instructor instructor = getInstructorOrThrow(request.id());
+		instructor.update(request.name(), request.introduction());
+		return instructorRepository.save(instructor);
+	}
+
+	@Override
+	@Transaction
+	public Instructor delete(InstructorDeleteRequest request) {
+		Instructor instructor = getInstructorOrThrow(request.id());
+		instructorRepository.deleteById(request.id());
+		return instructor;
+	}
+
+	private Instructor getInstructorOrThrow(Long id) {
+		return instructorRepository.findById(id)
+			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR));
+	}
+}

--- a/src/main/java/com/lxp/service/InstructorService.java
+++ b/src/main/java/com/lxp/service/InstructorService.java
@@ -6,48 +6,17 @@ import com.lxp.controller.request.InstructorDeleteRequest;
 import com.lxp.controller.request.InstructorRegisterRequest;
 import com.lxp.controller.request.InstructorUpdateRequest;
 import com.lxp.domain.Instructor;
-import com.lxp.exception.ErrorCode;
-import com.lxp.exception.LxpException;
-import com.lxp.repository.InstructorRepository;
+public interface InstructorService {
 
-import lombok.RequiredArgsConstructor;
+	Instructor register(InstructorRegisterRequest request);
 
-@RequiredArgsConstructor
-public class InstructorService {
+	List<Instructor> findAll();
 
-	private final InstructorRepository instructorRepository;
+	Instructor findById(Long id);
 
-	public Instructor register(InstructorRegisterRequest request) {
-		Instructor instructor = Instructor.create(request.name(), request.introduction());
-		return instructorRepository.save(instructor);
-	}
+	Instructor findDetailById(Long id);
 
-	public List<Instructor> findAll() {
-		return instructorRepository.findAll();
-	}
+	Instructor update(InstructorUpdateRequest request);
 
-	public Instructor findById(Long id) {
-		return getInstructorOrThrow(id);
-	}
-
-	public Instructor findDetailById(Long id) {
-		return getInstructorOrThrow(id);
-	}
-
-	public Instructor update(InstructorUpdateRequest request) {
-		Instructor instructor = getInstructorOrThrow(request.id());
-		instructor.update(request.name(), request.introduction());
-		return instructorRepository.save(instructor);
-	}
-
-	public Instructor delete(InstructorDeleteRequest request) {
-		Instructor instructor = getInstructorOrThrow(request.id());
-		instructorRepository.deleteById(request.id());
-		return instructor;
-	}
-
-	private Instructor getInstructorOrThrow(Long id) {
-		return instructorRepository.findById(id)
-			.orElseThrow(() -> new LxpException(ErrorCode.NOT_FOUND_INSTRUCTOR));
-	}
+	Instructor delete(InstructorDeleteRequest request);
 }

--- a/src/main/java/com/lxp/transaction/JdbcTransactionManager.java
+++ b/src/main/java/com/lxp/transaction/JdbcTransactionManager.java
@@ -1,0 +1,73 @@
+package com.lxp.transaction;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import com.lxp.exception.ErrorCode;
+import com.lxp.exception.LxpException;
+import com.lxp.repository.jdbc.ConnectionProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JdbcTransactionManager implements TransactionManager {
+
+	private final ConnectionProvider connectionProvider;
+
+	@Override
+	public TransactionStatus begin() {
+		if (TransactionSynchronizationManager.hasConnection()) {
+			return TransactionStatus.participating(TransactionSynchronizationManager.getConnection());
+		}
+
+		try {
+			Connection connection = connectionProvider.getConnection();
+			connection.setAutoCommit(false);
+			TransactionSynchronizationManager.bind(connection);
+			return TransactionStatus.started(connection);
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	@Override
+	public void commit(TransactionStatus transactionStatus) {
+		if (!transactionStatus.newTransaction()) {
+			return;
+		}
+
+		try {
+			transactionStatus.connection().commit();
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			close(transactionStatus.connection());
+		}
+	}
+
+	@Override
+	public void rollback(TransactionStatus transactionStatus) {
+		if (!transactionStatus.newTransaction()) {
+			return;
+		}
+
+		try {
+			transactionStatus.connection().rollback();
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			close(transactionStatus.connection());
+		}
+	}
+
+	private void close(Connection connection) {
+		try {
+			connection.setAutoCommit(true);
+			connection.close();
+		} catch (SQLException e) {
+			throw new LxpException(ErrorCode.INTERNAL_SERVER_ERROR);
+		} finally {
+			TransactionSynchronizationManager.clear();
+		}
+	}
+}

--- a/src/main/java/com/lxp/transaction/Transaction.java
+++ b/src/main/java/com/lxp/transaction/Transaction.java
@@ -1,0 +1,11 @@
+package com.lxp.transaction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Transaction {
+}

--- a/src/main/java/com/lxp/transaction/TransactionManager.java
+++ b/src/main/java/com/lxp/transaction/TransactionManager.java
@@ -1,0 +1,10 @@
+package com.lxp.transaction;
+
+public interface TransactionManager {
+
+	TransactionStatus begin();
+
+	void commit(TransactionStatus transactionStatus);
+
+	void rollback(TransactionStatus transactionStatus);
+}

--- a/src/main/java/com/lxp/transaction/TransactionProxyFactory.java
+++ b/src/main/java/com/lxp/transaction/TransactionProxyFactory.java
@@ -1,0 +1,19 @@
+package com.lxp.transaction;
+
+import java.lang.reflect.Proxy;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TransactionProxyFactory {
+
+	private final TransactionManager transactionManager;
+
+	public <T> T createProxy(Class<T> serviceType, T target) {
+		return serviceType.cast(Proxy.newProxyInstance(
+			serviceType.getClassLoader(),
+			new Class<?>[]{serviceType},
+			new TransactionalInvocationHandler(target, transactionManager)
+		));
+	}
+}

--- a/src/main/java/com/lxp/transaction/TransactionStatus.java
+++ b/src/main/java/com/lxp/transaction/TransactionStatus.java
@@ -1,0 +1,17 @@
+package com.lxp.transaction;
+
+import java.sql.Connection;
+
+public record TransactionStatus(
+	Connection connection,
+	boolean newTransaction
+) {
+
+	public static TransactionStatus participating(Connection connection) {
+		return new TransactionStatus(connection, false);
+	}
+
+	public static TransactionStatus started(Connection connection) {
+		return new TransactionStatus(connection, true);
+	}
+}

--- a/src/main/java/com/lxp/transaction/TransactionSynchronizationManager.java
+++ b/src/main/java/com/lxp/transaction/TransactionSynchronizationManager.java
@@ -1,0 +1,32 @@
+package com.lxp.transaction;
+
+import java.sql.Connection;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TransactionSynchronizationManager {
+
+	private static final ThreadLocal<Connection> CONNECTION_HOLDER = new ThreadLocal<>();
+
+	public static void bind(Connection connection) {
+		CONNECTION_HOLDER.set(connection);
+	}
+
+	public static boolean hasConnection() {
+		return CONNECTION_HOLDER.get() != null;
+	}
+
+	public static Connection getConnection() {
+		return CONNECTION_HOLDER.get();
+	}
+
+	public static boolean isCurrentConnection(Connection connection) {
+		return connection != null && connection == CONNECTION_HOLDER.get();
+	}
+
+	public static void clear() {
+		CONNECTION_HOLDER.remove();
+	}
+}

--- a/src/main/java/com/lxp/transaction/TransactionalInvocationHandler.java
+++ b/src/main/java/com/lxp/transaction/TransactionalInvocationHandler.java
@@ -1,0 +1,45 @@
+package com.lxp.transaction;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TransactionalInvocationHandler implements InvocationHandler {
+
+	private final Object target;
+	private final TransactionManager transactionManager;
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
+		if (!isTransactional(targetMethod)) {
+			return invokeTarget(targetMethod, args);
+		}
+
+		TransactionStatus transactionStatus = transactionManager.begin();
+		try {
+			Object result = invokeTarget(targetMethod, args);
+			transactionManager.commit(transactionStatus);
+			return result;
+		} catch (Throwable throwable) {
+			transactionManager.rollback(transactionStatus);
+			throw throwable;
+		}
+	}
+
+	private Object invokeTarget(Method targetMethod, Object[] args) throws Throwable {
+		try {
+			return targetMethod.invoke(target, args);
+		} catch (InvocationTargetException exception) {
+			throw exception.getTargetException();
+		}
+	}
+
+	private boolean isTransactional(Method targetMethod) {
+		return targetMethod.isAnnotationPresent(Transaction.class)
+			|| target.getClass().isAnnotationPresent(Transaction.class);
+	}
+}

--- a/src/test/java/com/lxp/repository/jdbc/JdbcRepositoryMysqlTest.java
+++ b/src/test/java/com/lxp/repository/jdbc/JdbcRepositoryMysqlTest.java
@@ -1,0 +1,74 @@
+package com.lxp.repository.jdbc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.domain.Content;
+import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
+import com.lxp.domain.enums.ContentType;
+import com.lxp.domain.enums.Level;
+
+@DisplayName("JdbcRepository MySQL 테스트")
+class JdbcRepositoryMysqlTest extends MysqlIntegrationSupport {
+
+	private JdbcInstructorRepository instructorRepository;
+	private JdbcCourseRepository courseRepository;
+	private JdbcContentRepository contentRepository;
+
+	@BeforeEach
+	void setUp() {
+		resetDatabase();
+		JdbcTemplate jdbcTemplate = jdbcTemplate();
+		this.instructorRepository = new JdbcInstructorRepository(jdbcTemplate);
+		this.courseRepository = new JdbcCourseRepository(jdbcTemplate);
+		this.contentRepository = new JdbcContentRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("성공 - 강사를 저장하고 조회한다")
+	void saveAndFindInstructor() {
+		Instructor savedInstructor = instructorRepository.save(Instructor.create("김남준", "자바 강사"));
+
+		Instructor foundInstructor = instructorRepository.findById(savedInstructor.getId()).orElseThrow();
+
+		assertThat(foundInstructor.getId()).isEqualTo(savedInstructor.getId());
+		assertThat(foundInstructor.getName()).isEqualTo("김남준");
+		assertThat(foundInstructor.getIntroduction()).isEqualTo("자바 강사");
+	}
+
+	@Test
+	@DisplayName("성공 - 강의를 soft delete 하면 조회되지 않는다")
+	void deleteCourse_softDelete() {
+		Instructor instructor = instructorRepository.save(Instructor.create("김남준", "자바 강사"));
+		Course savedCourse = courseRepository.save(
+			Course.create(instructor.getId(), "Java 입문", "기초 문법", 10000, Level.LOW)
+		);
+
+		courseRepository.deleteById(savedCourse.getId());
+
+		assertThat(courseRepository.findById(savedCourse.getId())).isEmpty();
+		assertThat(courseRepository.findAll()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("성공 - 콘텐츠를 강의 순서대로 조회한다")
+	void findAllContent_orderBySeq() {
+		Instructor instructor = instructorRepository.save(Instructor.create("김남준", "자바 강사"));
+		Course course = courseRepository.save(
+			Course.create(instructor.getId(), "Java 입문", "기초 문법", 10000, Level.LOW)
+		);
+		contentRepository.save(Content.create(course.getId(), "for 문", "설명", ContentType.TEXT, 2));
+		contentRepository.save(Content.create(course.getId(), "원시타입", "설명", ContentType.TEXT, 1));
+
+		List<Content> contents = contentRepository.findAll();
+
+		assertThat(contents).extracting(Content::getTitle)
+			.containsExactly("원시타입", "for 문");
+	}
+}

--- a/src/test/java/com/lxp/repository/jdbc/JdbcTemplateTest.java
+++ b/src/test/java/com/lxp/repository/jdbc/JdbcTemplateTest.java
@@ -1,0 +1,38 @@
+package com.lxp.repository.jdbc;
+
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.transaction.TransactionSynchronizationManager;
+
+@DisplayName("JdbcTemplate 테스트")
+class JdbcTemplateTest {
+
+	@AfterEach
+	void tearDown() {
+		TransactionSynchronizationManager.clear();
+	}
+
+	@Test
+	@DisplayName("성공 - 트랜잭션 연결이 있으면 새 연결을 만들지 않는다")
+	void update_useTransactionalConnection() throws Exception {
+		ConnectionProvider connectionProvider = mock(ConnectionProvider.class);
+		Connection connection = mock(Connection.class);
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		when(connection.prepareStatement("UPDATE sample SET name = ?")).thenReturn(preparedStatement);
+		TransactionSynchronizationManager.bind(connection);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(connectionProvider);
+
+		jdbcTemplate.update("UPDATE sample SET name = ?", ps -> ps.setString(1, "test"));
+
+		verifyNoInteractions(connectionProvider);
+		verify(connection, never()).close();
+		verify(preparedStatement).close();
+	}
+}

--- a/src/test/java/com/lxp/repository/jdbc/MysqlIntegrationSupport.java
+++ b/src/test/java/com/lxp/repository/jdbc/MysqlIntegrationSupport.java
@@ -1,0 +1,85 @@
+package com.lxp.repository.jdbc;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Assumptions;
+
+import com.lxp.config.AppProperties;
+import com.lxp.config.ConfigLoader;
+
+public abstract class MysqlIntegrationSupport {
+
+	protected static final String TEST_CONFIG = "config-test-mysql.yml";
+
+	protected AppProperties.DatabaseProperties databaseProperties() {
+		return new ConfigLoader().load(TEST_CONFIG).db();
+	}
+
+	protected ConnectionProvider connectionProvider() {
+		return DriverManagerConnectionProvider.from(databaseProperties());
+	}
+
+	protected JdbcTemplate jdbcTemplate() {
+		return new JdbcTemplate(connectionProvider());
+	}
+
+	protected void assumeMysqlAvailable() {
+		AppProperties.DatabaseProperties properties = databaseProperties();
+		try (Connection ignored = DriverManager.getConnection(
+			properties.url(),
+			properties.username(),
+			properties.password()
+		)) {
+			// no-op
+		} catch (SQLException exception) {
+			Assumptions.assumeTrue(false, "MySQL test database unavailable: " + exception.getMessage());
+		}
+	}
+
+	protected void resetDatabase() {
+		assumeMysqlAvailable();
+		AppProperties.DatabaseProperties properties = databaseProperties();
+		try (
+			Connection connection = DriverManager.getConnection(
+				properties.url(),
+				properties.username(),
+				properties.password()
+			);
+			Statement statement = connection.createStatement()
+		) {
+			statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+			statement.execute("DROP TABLE IF EXISTS contents");
+			statement.execute("DROP TABLE IF EXISTS courses");
+			statement.execute("DROP TABLE IF EXISTS instructors");
+			statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+			for (String sql : ddlStatements()) {
+				statement.execute(sql);
+			}
+		} catch (SQLException exception) {
+			throw new IllegalStateException("MySQL test schema setup failed", exception);
+		}
+	}
+
+	private String[] ddlStatements() {
+		try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("ddl.sql")) {
+			if (inputStream == null) {
+				throw new IllegalStateException("ddl.sql not found");
+			}
+			String ddl = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+			return Arrays.stream(ddl.split(";"))
+				.map(String::trim)
+				.filter(sql -> !sql.isBlank())
+				.toArray(String[]::new);
+		} catch (IOException exception) {
+			throw new IllegalStateException("Failed to read ddl.sql", exception);
+		}
+	}
+}

--- a/src/test/java/com/lxp/service/ContentServiceTest.java
+++ b/src/test/java/com/lxp/service/ContentServiceTest.java
@@ -37,7 +37,7 @@ class ContentServiceTest {
 	private ContentRepository contentRepository;
 
 	@InjectMocks
-	private ContentService contentService;
+	private DefaultContentService contentService;
 
 	@Test
 	@DisplayName("성공 - 콘텐츠를 등록하면 다음 seq를 부여한다")

--- a/src/test/java/com/lxp/service/CourseServiceTest.java
+++ b/src/test/java/com/lxp/service/CourseServiceTest.java
@@ -44,7 +44,7 @@ class CourseServiceTest {
 	private InstructorRepository instructorRepository;
 
 	@InjectMocks
-	private CourseService courseService;
+	private DefaultCourseService courseService;
 
 	@Test
 	@DisplayName("성공 - 강의와 콘텐츠를 함께 등록한다")

--- a/src/test/java/com/lxp/service/InstructorServiceTest.java
+++ b/src/test/java/com/lxp/service/InstructorServiceTest.java
@@ -30,7 +30,7 @@ class InstructorServiceTest {
 	private InstructorRepository instructorRepository;
 
 	@InjectMocks
-	private InstructorService instructorService;
+	private DefaultInstructorService instructorService;
 
 	@Test
 	@DisplayName("성공 - 강사를 등록한다")

--- a/src/test/java/com/lxp/transaction/JdbcTransactionManagerTest.java
+++ b/src/test/java/com/lxp/transaction/JdbcTransactionManagerTest.java
@@ -1,0 +1,70 @@
+package com.lxp.transaction;
+
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.repository.jdbc.ConnectionProvider;
+
+@DisplayName("JdbcTransactionManager 테스트")
+class JdbcTransactionManagerTest {
+
+	@AfterEach
+	void tearDown() {
+		TransactionSynchronizationManager.clear();
+	}
+
+	@Test
+	@DisplayName("성공 - 트랜잭션 시작 후 커밋하면 연결을 정리한다")
+	void beginAndCommit() throws Exception {
+		ConnectionProvider connectionProvider = mock(ConnectionProvider.class);
+		Connection connection = mock(Connection.class);
+		when(connectionProvider.getConnection()).thenReturn(connection);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(connectionProvider);
+
+		TransactionStatus transactionStatus = transactionManager.begin();
+		transactionManager.commit(transactionStatus);
+
+		verify(connection).setAutoCommit(false);
+		verify(connection).commit();
+		verify(connection).setAutoCommit(true);
+		verify(connection).close();
+	}
+
+	@Test
+	@DisplayName("성공 - 트랜잭션 시작 후 롤백하면 연결을 정리한다")
+	void beginAndRollback() throws Exception {
+		ConnectionProvider connectionProvider = mock(ConnectionProvider.class);
+		Connection connection = mock(Connection.class);
+		when(connectionProvider.getConnection()).thenReturn(connection);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(connectionProvider);
+
+		TransactionStatus transactionStatus = transactionManager.begin();
+		transactionManager.rollback(transactionStatus);
+
+		verify(connection).setAutoCommit(false);
+		verify(connection).rollback();
+		verify(connection).setAutoCommit(true);
+		verify(connection).close();
+	}
+
+	@Test
+	@DisplayName("성공 - 이미 트랜잭션이 있으면 기존 연결에 참여한다")
+	void begin_participateExistingTransaction() throws Exception {
+		ConnectionProvider connectionProvider = mock(ConnectionProvider.class);
+		Connection connection = mock(Connection.class);
+		TransactionSynchronizationManager.bind(connection);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(connectionProvider);
+
+		TransactionStatus transactionStatus = transactionManager.begin();
+		transactionManager.commit(transactionStatus);
+
+		verifyNoInteractions(connectionProvider);
+		verify(connection, never()).commit();
+		verify(connection, never()).close();
+	}
+}

--- a/src/test/java/com/lxp/transaction/TransactionMysqlIntegrationTest.java
+++ b/src/test/java/com/lxp/transaction/TransactionMysqlIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.lxp.transaction;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lxp.domain.Course;
+import com.lxp.domain.Instructor;
+import com.lxp.domain.enums.Level;
+import com.lxp.repository.CourseRepository;
+import com.lxp.repository.InstructorRepository;
+import com.lxp.repository.jdbc.JdbcCourseRepository;
+import com.lxp.repository.jdbc.JdbcInstructorRepository;
+import com.lxp.repository.jdbc.JdbcTemplate;
+import com.lxp.repository.jdbc.MysqlIntegrationSupport;
+
+@DisplayName("Transaction MySQL 통합 테스트")
+class TransactionMysqlIntegrationTest extends MysqlIntegrationSupport {
+
+	private CourseRepository courseRepository;
+	private InstructorRepository instructorRepository;
+	private SampleTransactionalService service;
+
+	@BeforeEach
+	void setUp() {
+		resetDatabase();
+		JdbcTemplate jdbcTemplate = jdbcTemplate();
+		this.courseRepository = new JdbcCourseRepository(jdbcTemplate);
+		this.instructorRepository = new JdbcInstructorRepository(jdbcTemplate);
+
+		SampleTransactionalService target = new SampleTransactionalServiceImpl(instructorRepository, courseRepository);
+		this.service = new TransactionProxyFactory(new JdbcTransactionManager(connectionProvider()))
+			.createProxy(SampleTransactionalService.class, target);
+	}
+
+	@Test
+	@DisplayName("성공 - 트랜잭션 메서드가 끝나면 함께 커밋된다")
+	void commit() {
+		service.saveAll();
+
+		assertThat(instructorRepository.findAll()).hasSize(1);
+		assertThat(courseRepository.findAll()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("실패 - 트랜잭션 메서드 중 예외가 발생하면 함께 롤백된다")
+	void rollback() {
+		assertThatThrownBy(service::saveAllAndFail)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("rollback");
+
+		assertThat(instructorRepository.findAll()).isEmpty();
+		assertThat(courseRepository.findAll()).isEmpty();
+	}
+
+	private interface SampleTransactionalService {
+		void saveAll();
+
+		void saveAllAndFail();
+	}
+
+	private static class SampleTransactionalServiceImpl implements SampleTransactionalService {
+
+		private final InstructorRepository instructorRepository;
+		private final CourseRepository courseRepository;
+
+		private SampleTransactionalServiceImpl(
+			InstructorRepository instructorRepository,
+			CourseRepository courseRepository
+		) {
+			this.instructorRepository = instructorRepository;
+			this.courseRepository = courseRepository;
+		}
+
+		@Override
+		@Transaction
+		public void saveAll() {
+			Instructor instructor = instructorRepository.save(Instructor.create("김남준", "자바 강사"));
+			courseRepository.save(Course.create(instructor.getId(), "Java 입문", "기초 문법", 10000, Level.LOW));
+		}
+
+		@Override
+		@Transaction
+		public void saveAllAndFail() {
+			Instructor instructor = instructorRepository.save(Instructor.create("김남준", "자바 강사"));
+			courseRepository.save(Course.create(instructor.getId(), "Java 입문", "기초 문법", 10000, Level.LOW));
+			throw new IllegalStateException("rollback");
+		}
+	}
+}

--- a/src/test/java/com/lxp/transaction/TransactionalInvocationHandlerTest.java
+++ b/src/test/java/com/lxp/transaction/TransactionalInvocationHandlerTest.java
@@ -1,0 +1,85 @@
+package com.lxp.transaction;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TransactionalInvocationHandler 테스트")
+class TransactionalInvocationHandlerTest {
+
+	@Test
+	@DisplayName("성공 - @Transaction 메서드 호출 시 트랜잭션을 시작하고 커밋한다")
+	void invoke_transactionalMethod() {
+		TransactionManager transactionManager = mock(TransactionManager.class);
+		TransactionStatus transactionStatus = new TransactionStatus(null, true);
+		when(transactionManager.begin()).thenReturn(transactionStatus);
+		SampleService proxy = new TransactionProxyFactory(transactionManager)
+			.createProxy(SampleService.class, new SampleServiceImpl());
+
+		String result = proxy.save();
+
+		assertThat(result).isEqualTo("saved");
+		verify(transactionManager).begin();
+		verify(transactionManager).commit(transactionStatus);
+		verify(transactionManager, never()).rollback(any());
+	}
+
+	@Test
+	@DisplayName("성공 - @Transaction 없는 메서드는 트랜잭션 없이 호출한다")
+	void invoke_nonTransactionalMethod() {
+		TransactionManager transactionManager = mock(TransactionManager.class);
+		SampleService proxy = new TransactionProxyFactory(transactionManager)
+			.createProxy(SampleService.class, new SampleServiceImpl());
+
+		String result = proxy.find();
+
+		assertThat(result).isEqualTo("found");
+		verifyNoInteractions(transactionManager);
+	}
+
+	@Test
+	@DisplayName("실패 - @Transaction 메서드에서 예외가 발생하면 롤백한다")
+	void invoke_transactionalMethodRollback() {
+		TransactionManager transactionManager = mock(TransactionManager.class);
+		TransactionStatus transactionStatus = new TransactionStatus(null, true);
+		when(transactionManager.begin()).thenReturn(transactionStatus);
+		SampleService proxy = new TransactionProxyFactory(transactionManager)
+			.createProxy(SampleService.class, new SampleServiceImpl());
+
+		assertThatThrownBy(proxy::fail)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("boom");
+		verify(transactionManager).rollback(transactionStatus);
+		verify(transactionManager, never()).commit(any());
+	}
+
+	private interface SampleService {
+		String save();
+
+		String find();
+
+		String fail();
+	}
+
+	private static class SampleServiceImpl implements SampleService {
+
+		@Override
+		@Transaction
+		public String save() {
+			return "saved";
+		}
+
+		@Override
+		public String find() {
+			return "found";
+		}
+
+		@Override
+		@Transaction
+		public String fail() {
+			throw new IllegalStateException("boom");
+		}
+	}
+}

--- a/src/test/resources/config-test-mysql.yml
+++ b/src/test/resources/config-test-mysql.yml
@@ -1,0 +1,7 @@
+repository:
+  mode: jdbc
+
+db:
+  url: "jdbc:mysql://localhost:3306/lxp_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8"
+  username: "root"
+  password: "root"


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #22

## 📌 개요
- JDBC 모드에서 서비스 계층 트랜잭션 프록시를 적용합니다.
- `TransactionalInvocationHandler` `JdbcTransactionManager`의 프록시 패턴을 위주로 보시면 좋을 듯 합니다!

## ✨ 변경 사항
- 서비스 인터페이스와 기본 구현체를 분리했습니다.
- JDBC 트랜잭션 매니저, 프록시, 동기화 관리자를 추가했습니다.
- JDBC/트랜잭션 단위 테스트와 MySQL 통합 테스트를 추가했습니다.

## 🔥 변경 이유(선택)
- JDBC 저장소 기반 변경과 트랜잭션 적용 변경을 분리해 리뷰 범위를 명확히 하기 위해서입니다.

## 🧪 테스트
- [x] 로컬 테스트 완료

## 🤔 고민한 부분 (선택)
- JDBC 모드에서만 프록시를 적용하고 InMemory 단계 동작은 유지했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [ ] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * MySQL 데이터베이스 지원 추가: 인메모리 저장소 대신 MySQL 데이터베이스를 백엔드로 사용할 수 있습니다.
  * YAML 설정 파일을 통한 구성 관리 지원: `config.yml` 파일로 저장소 모드와 데이터베이스 연결 정보를 설정할 수 있습니다.
  * 트랜잭션 관리 기능 추가: 데이터 일관성을 보장하는 트랜잭션 처리 지원.

* **테스트**
  * MySQL 통합 테스트 및 트랜잭션 동작 검증 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->